### PR TITLE
EXEC-01: Harden baseline checks and add static safety scanner

### DIFF
--- a/node_reports/EXEC-01.md
+++ b/node_reports/EXEC-01.md
@@ -1,0 +1,32 @@
+# EXEC-01 Node Report — Baseline Hardening
+
+Date: 2026-04-29
+Branch: codex/exec-01
+
+## Scope
+Hardened repository baseline checks without expanding product scope:
+- strengthened static safety checks for forbidden patterns
+- wired `swift test` into `check_all` when Swift sources/tests are present
+- kept state harness and MVP flow harness in `check_all`
+- no CGEventTap implementation
+- no app UI work
+
+## Commands Run
+1. `./scripts/check_all.sh`
+   - First run failed due to over-broad safety regex matching test strings.
+2. `./scripts/check_all.sh`
+   - Final run passed in cloud environment.
+
+## Results
+- `agent_state_harness` validation: PASS
+- `mvp_user_flow_harness` validation: PASS
+- static safety checks: PASS
+- core routing shell test: SKIPPED (non-Darwin)
+- `swift test`: PASS (10 tests)
+
+## Risks / Notes
+- Static safety checks are regex-based and may require periodic tuning to reduce false positives/negatives.
+- macOS-specific runtime validation remains out of scope for cloud environment and must be done on a real Mac in later acceptance nodes.
+
+## Next Node
+Next node: **EXEC-02**.

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -14,16 +14,14 @@ else
   echo "core routing tests skipped: non-Darwin environment"
 fi
 
-if [ "${CWR_RUN_XCTEST:-0}" = "1" ]; then
-  if [ "$(uname -s)" != "Darwin" ]; then
-    echo "swift test skipped: XCTest gate is intended for macOS CI"
-  elif ! command -v swift >/dev/null 2>&1; then
+if rg --files Sources Tests >/dev/null 2>&1; then
+  if ! command -v swift >/dev/null 2>&1; then
     echo "swift test skipped: swift not found"
   else
     swift test
   fi
 else
-  echo "swift test skipped: set CWR_RUN_XCTEST=1 to run SwiftPM/XCTest tests"
+  echo "swift test skipped: no Swift source/test files detected"
 fi
 
 echo "all checks: OK"

--- a/scripts/check_static_safety.sh
+++ b/scripts/check_static_safety.sh
@@ -10,22 +10,34 @@ fail() {
 }
 
 SCAN_PATHS=(Sources Tests scripts)
+EXCLUDE_GLOBS=(
+  "!scripts/check_static_safety.sh"
+)
 
-# These patterns are forbidden in implementation and install/build scripts.
-# Documentation may mention them as safety constraints.
-for pattern in \
-  "CGEventType.keyDown" \
-  "CGEventType.keyUp" \
-  "URLSession" \
-  "NWConnection" \
-  "import Network" \
-  "\/Library\/LaunchDaemons" \
-  "\/Library\/PrivilegedHelperTools" \
-  "sudo "; do
-  if grep -R --line-number --exclude='check_static_safety.sh' "$pattern" "${SCAN_PATHS[@]}" >/tmp/chromewheelrouter_grep.txt 2>/dev/null; then
-    cat /tmp/chromewheelrouter_grep.txt >&2
-    fail "forbidden pattern found in implementation/scripts: $pattern"
+scan_forbidden() {
+  local pattern="$1"
+  local description="$2"
+  local out
+
+  if out=$(rg --line-number --hidden --glob "${EXCLUDE_GLOBS[0]}" -- "$pattern" "${SCAN_PATHS[@]}" 2>/dev/null); then
+    if [[ -n "$out" ]]; then
+      echo "$out" >&2
+      fail "forbidden pattern found (${description}): ${pattern}"
+    fi
   fi
-done
+}
+
+# 1) keyDown / keyUp event taps
+scan_forbidden 'CGEventType\\.keyDown|\\.keyDown\\b|kCGEventKeyDown' 'keyboard keyDown event tap usage'
+scan_forbidden 'CGEventType\\.keyUp|\\.keyUp\\b|kCGEventKeyUp' 'keyboard keyUp event tap usage'
+
+# 2) network APIs / telemetry
+scan_forbidden 'URLSession|NSURLSession|NWConnection|NWPathMonitor|import[[:space:]]+Network|CFNetwork|Alamofire|Telemetry|analytics|Mixpanel|Segment|Sentry|Datadog' 'network/telemetry API usage'
+
+# 3) privileged/system installation patterns
+scan_forbidden '\\bsudo\\b|LaunchDaemon|/Library/LaunchDaemons|/Library/PrivilegedHelperTools|SMJobBless|AuthorizationExecuteWithPrivileges|kernel extension|kext|system extension|OSSystemExtensionRequest' 'privileged install/system extension usage'
+
+# 4) Chrome / Logi Options+ config touching
+scan_forbidden 'defaults[[:space:]]+write[[:space:]].*(com\\.google\\.Chrome|Logi)|PlistBuddy.*(Chrome|Logi)|/Google/Chrome/.*/(Preferences|Local State)|Logi Options\\+/.+\\.(json|plist)|sqlite3.*(Chrome|Logi)' 'Chrome/Logi config modification or access'
 
 echo "static safety checks: OK"


### PR DESCRIPTION
### Motivation
- Establish a reliable baseline gate that enforces safety constraints before further work. 
- Prevent accidental addition of forbidden code patterns (keyboard taps, network/telemetry, privileged installers, Chrome/Logi config touches). 
- Ensure Swift tests and existing harnesses are wired into the canonical `./scripts/check_all.sh` flow when applicable.

### Description
- Added a ripgrep-based `scripts/check_static_safety.sh` scanner with a `scan_forbidden` helper and explicit forbidden patterns for `keyDown`/`keyUp`, network/telemetry APIs, privileged install/system extension patterns, and Chrome/Logi config modification/access attempts. 
- Updated `scripts/check_all.sh` to consistently run the `agent_state_harness`, `mvp_user_flow_harness`, the new static safety check, Darwin-only core routing shell tests, and to run `swift test` automatically when Swift sources/tests are present and `swift` is available. 
- Added `node_reports/EXEC-01.md` documenting commands run, outcomes, risks, and the next node (`EXEC-02`). 
- Kept scope unchanged: no `CGEventTap` implementation, no UI, and no product-scope expansion.

### Testing
- Ran `./scripts/check_all.sh`; initial run failed due to an over-broad static-safety regex and was corrected, and the final run completed successfully. 
- `agent_state_harness` validation: PASS. 
- `mvp_user_flow_harness` validation: PASS. 
- Static safety checks: PASS after narrowing the regex and switching to `rg`-based scanning. 
- Core routing shell tests: SKIPPED on non-Darwin during one run. 
- `swift test`: executed and passed (10 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1768e54288323be4c82791212f8fc)