### PR TITLE
EXEC-02: complete pure routing core and lock pass-through invariants

### DIFF
--- a/Sources/ChromeWheelRouterCore/Router.swift
+++ b/Sources/ChromeWheelRouterCore/Router.swift
@@ -14,7 +14,7 @@ public struct Router: Sendable {
             return .passThrough
         }
 
-        guard event.horizontalDelta != 0 else {
+        guard event.isHorizontalOnlyScroll else {
             return .passThrough
         }
 

--- a/Sources/ChromeWheelRouterCore/ScrollEventModel.swift
+++ b/Sources/ChromeWheelRouterCore/ScrollEventModel.swift
@@ -18,4 +18,8 @@ public struct ScrollEventModel: Sendable, Equatable {
         self.modifiers = modifiers
         self.routerEnabled = routerEnabled
     }
+
+    public var isHorizontalOnlyScroll: Bool {
+        horizontalDelta != 0 && verticalDelta == 0
+    }
 }

--- a/Tests/ChromeWheelRouterCoreTests/RouterTests.swift
+++ b/Tests/ChromeWheelRouterCoreTests/RouterTests.swift
@@ -26,6 +26,17 @@ final class RouterTests: XCTestCase {
         XCTAssertEqual(router.decide(event), .passThrough)
     }
 
+    func testChromeHorizontalAndVerticalSimultaneousPassesThrough() {
+        let event = ScrollEventModel(
+            frontmostBundleID: "com.google.Chrome",
+            horizontalDelta: 1,
+            verticalDelta: 1,
+            modifiers: [.option]
+        )
+
+        XCTAssertEqual(router.decide(event), .passThrough)
+    }
+
     func testChromeHorizontalNoModifierPassesThrough() {
         let event = ScrollEventModel(
             frontmostBundleID: "com.google.Chrome",

--- a/node_reports/EXEC-02.md
+++ b/node_reports/EXEC-02.md
@@ -1,0 +1,35 @@
+# EXEC-02 Node Report — Routing Core Completion
+
+Date: 2026-04-29
+Branch: codex/exec-02
+
+## Scope
+Completed and tightened pure Swift routing core behavior without expanding scope:
+- refined routing model with explicit horizontal-only scroll predicate in `ScrollEventModel`
+- updated `Router.decide` to require horizontal-only scrolling in addition to Chrome + Option-only + enabled state
+- expanded core unit tests with a simultaneous horizontal+vertical case to lock pass-through behavior
+- no macOS event tap implementation
+- no keyboard listener/injection implementation
+
+## Commands Run
+1. `./scripts/check_all.sh`
+2. `swift build -c release`
+
+## Results
+- `agent_state_harness` validation: PASS
+- `mvp_user_flow_harness` validation: PASS
+- static safety checks: PASS
+- core routing shell test: SKIPPED (non-Darwin)
+- `swift test` (via `check_all`): PASS (11 tests)
+- `swift build -c release`: PASS
+
+## Invariant Confirmation
+The tests and router logic enforce:
+- Only Chrome + Option-only + horizontal-only scroll can be converted into zoom and swallowed.
+- Non-matching events pass through unchanged.
+
+## Risks / Notes
+- Physical hardware behavior (MX Master + Logi Options+ + Chrome) remains out of scope for cloud validation and must be confirmed in later human acceptance nodes.
+
+## Next Node
+Next node: **EXEC-03**.

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -14,14 +14,22 @@ else
   echo "core routing tests skipped: non-Darwin environment"
 fi
 
-if rg --files Sources Tests >/dev/null 2>&1; then
+run_xtest="${CWR_RUN_XCTEST:-0}"
+has_swift_package=0
+if [ -f "Package.swift" ]; then
+  has_swift_package=1
+elif rg -l --glob '*.swift' . Sources Tests >/dev/null 2>&1; then
+  has_swift_package=1
+fi
+
+if [ "$run_xtest" = "1" ] || [ "$has_swift_package" = "1" ]; then
   if ! command -v swift >/dev/null 2>&1; then
     echo "swift test skipped: swift not found"
   else
     swift test
   fi
 else
-  echo "swift test skipped: no Swift source/test files detected"
+  echo "swift test skipped: no Swift package detected (set CWR_RUN_XCTEST=1 to force)"
 fi
 
 echo "all checks: OK"


### PR DESCRIPTION
### Motivation
- Make the pure Swift routing core explicit about horizontal-only scrolls so the pass-through invariant is unambiguous.
- Ensure the router only converts Chrome + Option-only + horizontal-only scrolls into zoom actions and swallows nothing else.
- Preserve the safety contract with unit tests that prove non-matching events always pass through.

### Description
- Added `isHorizontalOnlyScroll` to `ScrollEventModel` to express the horizontal-only predicate as a pure-model helper.
- Updated `Router.decide` to require `isHorizontalOnlyScroll` in addition to Chrome frontmost, Option-only, and enabled state before returning a zoom decision.
- Added a mixed-axis unit test (`horizontalDelta: 1`, `verticalDelta: 1`) to lock pass-through behavior and retained all required routing tests for Chrome/non-Chrome/modifiers/direction/disabled flows.
- Added `node_reports/EXEC-02.md` documenting scope, commands run, results, invariant confirmation, and next node.

### Testing
- Ran `./scripts/check_all.sh` which performs harness and static safety checks and reports success.
- Ran the core unit tests (`swift test`) which passed (11 tests) and confirmed the new mixed-axis test succeeded.
- Built with `swift build -c release` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18bf1eb1c832393f1761066b2de5d)