### PR TITLE
EXEC-03: add macOS scrollWheel-only event tap CLI spike

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,11 +10,27 @@ let package = Package(
         .library(
             name: "ChromeWheelRouterCore",
             targets: ["ChromeWheelRouterCore"]
+        ),
+        .library(
+            name: "ChromeWheelRouterMac",
+            targets: ["ChromeWheelRouterMac"]
+        ),
+        .executable(
+            name: "ChromeWheelRouterCLI",
+            targets: ["ChromeWheelRouterCLI"]
         )
     ],
     targets: [
         .target(
             name: "ChromeWheelRouterCore"
+        ),
+        .target(
+            name: "ChromeWheelRouterMac",
+            dependencies: ["ChromeWheelRouterCore"]
+        ),
+        .executableTarget(
+            name: "ChromeWheelRouterCLI",
+            dependencies: ["ChromeWheelRouterCore", "ChromeWheelRouterMac"]
         ),
         .testTarget(
             name: "ChromeWheelRouterCoreTests",

--- a/Sources/ChromeWheelRouterCLI/main.swift
+++ b/Sources/ChromeWheelRouterCLI/main.swift
@@ -1,0 +1,51 @@
+import Foundation
+import ChromeWheelRouterCore
+import ChromeWheelRouterMac
+
+
+struct CLI {
+    static func run(arguments: [String]) throws {
+        let mode = try parseMode(arguments: arguments)
+        let service = CGEventTapService(mode: mode)
+
+        guard service.start() else {
+            fputs("Failed to create scrollWheel-only event tap. Check macOS privacy permissions.\n", stderr)
+            Foundation.exit(1)
+        }
+
+        print("ChromeWheelRouterCLI started in --\(mode.rawValue) mode. Press Ctrl+C to stop.")
+        service.run()
+    }
+
+    private static func parseMode(arguments: [String]) throws -> EventTapMode {
+        let modes = arguments.filter { $0.hasPrefix("--") }
+        guard modes.count == 1 else {
+            printUsageAndExit()
+        }
+
+        switch modes[0] {
+        case "--listen-only":
+            return .listenOnly
+        case "--dry-run":
+            return .dryRun
+        case "--active":
+            return .active
+        default:
+            printUsageAndExit()
+        }
+    }
+
+    private static func printUsageAndExit() -> Never {
+        let usage = """
+        Usage: ChromeWheelRouterCLI [--listen-only|--dry-run|--active]
+
+        --listen-only Observe and log scroll classification only.
+        --dry-run     Classify matches but never swallow.
+        --active      Reserved for EXEC-04 behavior; EXEC-03 still passes through.
+        """
+        print(usage)
+        Foundation.exit(2)
+    }
+}
+
+try CLI.run(arguments: CommandLine.arguments.dropFirst().map { $0 })

--- a/Sources/ChromeWheelRouterMac/CGEventTapService.swift
+++ b/Sources/ChromeWheelRouterMac/CGEventTapService.swift
@@ -47,21 +47,45 @@ public final class CGEventTapService {
         return true
     }
 
-    public func run() { CFRunLoopRun() }
+    public func run() {
+        CFRunLoopRun()
+    }
 
     private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        guard type == .scrollWheel else { return Unmanaged.passUnretained(event) }
-
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard type == .scrollWheel else {
             return Unmanaged.passUnretained(event)
         }
 
         let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
-        let model = ScrollEventAdapter.makeModel(event: event, frontmostBundleID: frontmostBundleID, routerEnabled: isEnabled())
+        let model = ScrollEventAdapter.makeModel(
+            event: event,
+            frontmostBundleID: frontmostBundleID,
+            routerEnabled: isEnabled()
+        )
         let decision = router.decide(model)
-        print("mode=\(mode.rawValue) app=\(frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) modifiers=\(model.modifiers) decision=\(decision)")
+
+        log(decision: decision, model: model)
+
+        // EXEC-03 safety invariant: return original event in all modes.
         return Unmanaged.passUnretained(event)
+    }
+
+    private func log(decision: RouteDecision, model: ScrollEventModel) {
+        switch mode {
+        case .listenOnly:
+            print("mode=listen-only observed app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) modifiers=\(model.modifiers) decision=\(decision)")
+        case .dryRun:
+            print("mode=dry-run classified app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) decision=\(decision) action=pass-through")
+        case .active:
+            print("mode=active classified app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) decision=\(decision) action=pass-through-exec-03")
+        }
     }
 }
 #else
@@ -69,7 +93,11 @@ import ChromeWheelRouterCore
 
 public final class CGEventTapService {
     public init(router: Router = Router(), mode: EventTapMode, isEnabled: @escaping () -> Bool = { true }) {}
-    public func start() -> Bool { false }
+
+    public func start() -> Bool {
+        false
+    }
+
     public func run() {}
 }
 #endif

--- a/Sources/ChromeWheelRouterMac/CGEventTapService.swift
+++ b/Sources/ChromeWheelRouterMac/CGEventTapService.swift
@@ -1,0 +1,75 @@
+#if canImport(AppKit)
+import AppKit
+import CoreGraphics
+import ChromeWheelRouterCore
+
+public final class CGEventTapService {
+    private let router: Router
+    private let mode: EventTapMode
+    private let isEnabled: () -> Bool
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+
+    public init(
+        router: Router = Router(),
+        mode: EventTapMode,
+        isEnabled: @escaping () -> Bool = { true }
+    ) {
+        self.router = router
+        self.mode = mode
+        self.isEnabled = isEnabled
+    }
+
+    public func start() -> Bool {
+        let mask = CGEventMask(1 << CGEventType.scrollWheel.rawValue)
+        let callback: CGEventTapCallBack = { proxy, type, event, context in
+            guard let context else { return Unmanaged.passUnretained(event) }
+            let service = Unmanaged<CGEventTapService>.fromOpaque(context).takeUnretainedValue()
+            return service.handleEvent(proxy: proxy, type: type, event: event)
+        }
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: callback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else {
+            return false
+        }
+
+        eventTap = tap
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        return true
+    }
+
+    public func run() { CFRunLoopRun() }
+
+    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        guard type == .scrollWheel else { return Unmanaged.passUnretained(event) }
+
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: true) }
+            return Unmanaged.passUnretained(event)
+        }
+
+        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+        let model = ScrollEventAdapter.makeModel(event: event, frontmostBundleID: frontmostBundleID, routerEnabled: isEnabled())
+        let decision = router.decide(model)
+        print("mode=\(mode.rawValue) app=\(frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) modifiers=\(model.modifiers) decision=\(decision)")
+        return Unmanaged.passUnretained(event)
+    }
+}
+#else
+import ChromeWheelRouterCore
+
+public final class CGEventTapService {
+    public init(router: Router = Router(), mode: EventTapMode, isEnabled: @escaping () -> Bool = { true }) {}
+    public func start() -> Bool { false }
+    public func run() {}
+}
+#endif

--- a/Sources/ChromeWheelRouterMac/EventTapMode.swift
+++ b/Sources/ChromeWheelRouterMac/EventTapMode.swift
@@ -1,0 +1,5 @@
+public enum EventTapMode: String, Sendable {
+    case listenOnly = "listen-only"
+    case dryRun = "dry-run"
+    case active = "active"
+}

--- a/Sources/ChromeWheelRouterMac/ModifierState+CGEventFlags.swift
+++ b/Sources/ChromeWheelRouterMac/ModifierState+CGEventFlags.swift
@@ -1,0 +1,15 @@
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ChromeWheelRouterCore
+
+public extension ModifierState {
+    init(flags: CGEventFlags) {
+        self.init(
+            option: flags.contains(.maskAlternate),
+            command: flags.contains(.maskCommand),
+            shift: flags.contains(.maskShift),
+            control: flags.contains(.maskControl)
+        )
+    }
+}
+#endif

--- a/Sources/ChromeWheelRouterMac/ModifierState+CGEventFlags.swift
+++ b/Sources/ChromeWheelRouterMac/ModifierState+CGEventFlags.swift
@@ -4,12 +4,22 @@ import ChromeWheelRouterCore
 
 public extension ModifierState {
     init(flags: CGEventFlags) {
-        self.init(
-            option: flags.contains(.maskAlternate),
-            command: flags.contains(.maskCommand),
-            shift: flags.contains(.maskShift),
-            control: flags.contains(.maskControl)
-        )
+        var state: ModifierState = []
+
+        if flags.contains(.maskAlternate) {
+            state.insert(.option)
+        }
+        if flags.contains(.maskCommand) {
+            state.insert(.command)
+        }
+        if flags.contains(.maskShift) {
+            state.insert(.shift)
+        }
+        if flags.contains(.maskControl) {
+            state.insert(.control)
+        }
+
+        self = state
     }
 }
 #endif

--- a/Sources/ChromeWheelRouterMac/ScrollEventAdapter.swift
+++ b/Sources/ChromeWheelRouterMac/ScrollEventAdapter.swift
@@ -1,0 +1,24 @@
+#if canImport(CoreGraphics)
+import CoreGraphics
+import ChromeWheelRouterCore
+
+public enum ScrollEventAdapter {
+    public static func makeModel(
+        event: CGEvent,
+        frontmostBundleID: String,
+        routerEnabled: Bool
+    ) -> ScrollEventModel {
+        let horizontalDelta = Int64(event.getIntegerValueField(.scrollWheelEventDeltaAxis2))
+        let verticalDelta = Int64(event.getIntegerValueField(.scrollWheelEventDeltaAxis1))
+        let modifiers = ModifierState(flags: event.flags)
+
+        return ScrollEventModel(
+            frontmostBundleID: frontmostBundleID,
+            horizontalDelta: horizontalDelta,
+            verticalDelta: verticalDelta,
+            modifiers: modifiers,
+            routerEnabled: routerEnabled
+        )
+    }
+}
+#endif

--- a/node_reports/EXEC-03.md
+++ b/node_reports/EXEC-03.md
@@ -1,0 +1,48 @@
+# EXEC-03 Node Report — macOS Event Tap CLI Spike
+
+Date: 2026-04-29
+Branch: codex/exec-03
+
+## Scope
+Implemented a CLI spike for safe `scrollWheel` event observation and classification:
+- added `ChromeWheelRouterMac` target with a `CGEventTapService` using an event tap mask containing only `scrollWheel`
+- added `ScrollEventAdapter` for translating `CGEvent` into pure core `ScrollEventModel`
+- added `ChromeWheelRouterCLI` executable target with modes:
+  - `--listen-only`
+  - `--dry-run`
+  - `--active`
+- for EXEC-03, all modes return the original event (no swallowing)
+- no keyboard event listening
+- no keyboard injection
+
+## Commands Run
+1. `./scripts/check_all.sh`
+2. `swift build -c release`
+
+## Results
+- `agent_state_harness` validation: PASS
+- `mvp_user_flow_harness` validation: PASS
+- static safety checks: PASS
+- core routing shell test: SKIPPED (non-Darwin)
+- `swift test` (via `check_all`): PASS
+- `swift build -c release`: PASS
+
+## Safety Confirmation
+- Event tap mask includes only `scrollWheel`.
+- No keyDown/keyUp event tap added.
+- Callback does not perform disk IO, network IO, shell execution, sleep, or blocking locks.
+- No menu bar UI introduced in this node.
+
+## Manual Mac Verification Command (listen-only)
+Run locally on a real Mac (with required privacy permissions):
+
+```bash
+swift run ChromeWheelRouterCLI --listen-only
+```
+
+Expected behavior for EXEC-03:
+- CLI logs classification decisions.
+- Original scroll events continue to pass through unchanged.
+
+## Next Node
+Next node: **EXEC-04**.


### PR DESCRIPTION
### Motivation
- Provide a safe local CLI spike to observe and classify macOS `scrollWheel` events and exercise the macOS adapter layer without swallowing or injecting input in this node.
- Keep the hot-path callback minimal and scoped only to `scrollWheel` to satisfy the project's hard safety rules and prepare for later injection behavior in EXEC-04.

### Description
- Add new SwiftPM products and targets: `ChromeWheelRouterMac` and `ChromeWheelRouterCLI`, and wire them into `Package.swift`.
- Implement `CGEventTapService` that creates an event tap whose mask includes only `scrollWheel`, converts `CGEvent` into the core `ScrollEventModel`, calls `Router.decide`, logs the decision, and always returns the original event for EXEC-03.
- Add `ScrollEventAdapter` and `ModifierState` bridging to translate `CGEvent` fields and `CGEventFlags` into the pure core model, plus an `EventTapMode` enum and CLI entrypoint supporting `--listen-only`, `--dry-run`, and `--active` modes.
- Provide a non-macOS stub for `CGEventTapService` so the package builds on non-Darwin platforms and ensure all platform-specific imports are guarded with `canImport`.

### Testing
- Ran `./scripts/check_all.sh`, which reported `agent_state_harness: OK`, `mvp_user_flow_harness: OK`, and `static safety checks: OK`.
- Ran `swift test` (via `check_all`), which executed the core router tests and passed (11 tests, 0 failures).
- Built the CLI with `swift build -c release`, which completed successfully producing the `ChromeWheelRouterCLI` executable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18e95ef508323aa737b6e462d3bf0)