### PR TITLE
EXEC-04: Inject Chrome zoom shortcuts in active CLI mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         ),
         .testTarget(
             name: "ChromeWheelRouterCoreTests",
-            dependencies: ["ChromeWheelRouterCore"]
+            dependencies: ["ChromeWheelRouterCore", "ChromeWheelRouterMac"]
         )
     ]
 )

--- a/Sources/ChromeWheelRouterMac/CGEventTapService.swift
+++ b/Sources/ChromeWheelRouterMac/CGEventTapService.swift
@@ -7,17 +7,20 @@ public final class CGEventTapService {
     private let router: Router
     private let mode: EventTapMode
     private let isEnabled: () -> Bool
+    private let keyboardInjector: KeyboardInjecting
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
     public init(
         router: Router = Router(),
         mode: EventTapMode,
-        isEnabled: @escaping () -> Bool = { true }
+        isEnabled: @escaping () -> Bool = { true },
+        keyboardInjector: KeyboardInjecting = CGKeyboardInjector()
     ) {
         self.router = router
         self.mode = mode
         self.isEnabled = isEnabled
+        self.keyboardInjector = keyboardInjector
     }
 
     public func start() -> Bool {
@@ -70,29 +73,41 @@ public final class CGEventTapService {
             routerEnabled: isEnabled()
         )
         let decision = router.decide(model)
+        let action = EventAction.forMode(mode, decision: decision)
 
-        log(decision: decision, model: model)
+        log(decision: decision, model: model, action: action)
 
-        // EXEC-03 safety invariant: return original event in all modes.
-        return Unmanaged.passUnretained(event)
+        guard action == .injectAndSwallow else {
+            return Unmanaged.passUnretained(event)
+        }
+
+        let injected: Bool
+        switch decision {
+        case .zoomInAndSwallow:
+            injected = keyboardInjector.sendChromeZoomIn()
+        case .zoomOutAndSwallow:
+            injected = keyboardInjector.sendChromeZoomOut()
+        case .passThrough:
+            injected = false
+        }
+
+        return injected ? nil : Unmanaged.passUnretained(event)
     }
 
-    private func log(decision: RouteDecision, model: ScrollEventModel) {
-        switch mode {
-        case .listenOnly:
-            print("mode=listen-only observed app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) modifiers=\(model.modifiers) decision=\(decision)")
-        case .dryRun:
-            print("mode=dry-run classified app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) decision=\(decision) action=pass-through")
-        case .active:
-            print("mode=active classified app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) decision=\(decision) action=pass-through-exec-03")
-        }
+    private func log(decision: RouteDecision, model: ScrollEventModel, action: EventAction) {
+        print("mode=\(mode.rawValue) app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) decision=\(decision) action=\(action)")
     }
 }
 #else
 import ChromeWheelRouterCore
 
 public final class CGEventTapService {
-    public init(router: Router = Router(), mode: EventTapMode, isEnabled: @escaping () -> Bool = { true }) {}
+    public init(
+        router: Router = Router(),
+        mode: EventTapMode,
+        isEnabled: @escaping () -> Bool = { true },
+        keyboardInjector: KeyboardInjecting = CGKeyboardInjector()
+    ) {}
 
     public func start() -> Bool {
         false

--- a/Sources/ChromeWheelRouterMac/EventAction.swift
+++ b/Sources/ChromeWheelRouterMac/EventAction.swift
@@ -1,0 +1,19 @@
+import ChromeWheelRouterCore
+
+public enum EventAction: String, Sendable, Equatable {
+    case passThrough
+    case injectAndSwallow
+
+    static func forMode(_ mode: EventTapMode, decision: RouteDecision) -> EventAction {
+        guard mode == .active else {
+            return .passThrough
+        }
+
+        switch decision {
+        case .zoomInAndSwallow, .zoomOutAndSwallow:
+            return .injectAndSwallow
+        case .passThrough:
+            return .passThrough
+        }
+    }
+}

--- a/Sources/ChromeWheelRouterMac/KeyboardInjector.swift
+++ b/Sources/ChromeWheelRouterMac/KeyboardInjector.swift
@@ -1,0 +1,52 @@
+#if canImport(AppKit)
+import AppKit
+import CoreGraphics
+
+public protocol KeyboardInjecting: Sendable {
+    func sendChromeZoomIn() -> Bool
+    func sendChromeZoomOut() -> Bool
+}
+
+public struct CGKeyboardInjector: KeyboardInjecting {
+    public init() {}
+
+    public func sendChromeZoomIn() -> Bool {
+        sendCommandShortcut(keyCode: 24)
+    }
+
+    public func sendChromeZoomOut() -> Bool {
+        sendCommandShortcut(keyCode: 27)
+    }
+
+    private func sendCommandShortcut(keyCode: CGKeyCode) -> Bool {
+        guard
+            let source = CGEventSource(stateID: .combinedSessionState),
+            let keyPress = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
+            let keyRelease = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        else {
+            return false
+        }
+
+        keyPress.flags = .maskCommand
+        keyRelease.flags = .maskCommand
+        keyPress.post(tap: .cghidEventTap)
+        keyRelease.post(tap: .cghidEventTap)
+        return true
+    }
+}
+#else
+import Foundation
+
+public protocol KeyboardInjecting: Sendable {
+    func sendChromeZoomIn() -> Bool
+    func sendChromeZoomOut() -> Bool
+}
+
+public struct CGKeyboardInjector: KeyboardInjecting {
+    public init() {}
+
+    public func sendChromeZoomIn() -> Bool { false }
+
+    public func sendChromeZoomOut() -> Bool { false }
+}
+#endif

--- a/Tests/ChromeWheelRouterCoreTests/EventActionTests.swift
+++ b/Tests/ChromeWheelRouterCoreTests/EventActionTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import ChromeWheelRouterCore
+@testable import ChromeWheelRouterMac
+
+final class EventActionTests: XCTestCase {
+    func testListenOnlyNeverInjectsOrSwallows() {
+        XCTAssertEqual(EventAction.forMode(.listenOnly, decision: .zoomInAndSwallow), .passThrough)
+        XCTAssertEqual(EventAction.forMode(.listenOnly, decision: .zoomOutAndSwallow), .passThrough)
+    }
+
+    func testDryRunNeverInjectsOrSwallows() {
+        XCTAssertEqual(EventAction.forMode(.dryRun, decision: .zoomInAndSwallow), .passThrough)
+        XCTAssertEqual(EventAction.forMode(.dryRun, decision: .zoomOutAndSwallow), .passThrough)
+    }
+
+    func testActiveInjectsAndSwallowsOnlyMatchingDecisions() {
+        XCTAssertEqual(EventAction.forMode(.active, decision: .zoomInAndSwallow), .injectAndSwallow)
+        XCTAssertEqual(EventAction.forMode(.active, decision: .zoomOutAndSwallow), .injectAndSwallow)
+        XCTAssertEqual(EventAction.forMode(.active, decision: .passThrough), .passThrough)
+    }
+}

--- a/node_reports/EXEC-04.md
+++ b/node_reports/EXEC-04.md
@@ -1,0 +1,66 @@
+# EXEC-04 Node Report — Chrome Zoom Injection
+
+Date: 2026-04-29
+Branch: codex/exec-04
+
+## Scope
+Implemented real zoom injection for the CLI spike with strict mode safety:
+- added `KeyboardInjecting` abstraction and `CGKeyboardInjector` implementation for:
+  - Command + `=` (zoom in)
+  - Command + `-` (zoom out)
+- wired router decisions into event tap handling
+- implemented active mode behavior:
+  - only `zoomInAndSwallow` / `zoomOutAndSwallow` decisions attempt injection
+  - matching events return `nil` only when injection succeeds
+- ensured `listen-only` and `dry-run` never swallow and never inject
+- extracted mode/decision action policy into `EventAction`
+
+## Commands Run
+1. `./scripts/check_all.sh`
+2. `swift build -c release`
+
+## Results
+- static safety checks: PASS
+- `swift test`: PASS
+- `swift build -c release`: PASS
+
+## Safety Confirmation
+- event tap mask remains `scrollWheel`-only
+- unmatched events return original event
+- only Chrome + Option-only + horizontal scroll routes to swallow path (in active mode)
+- listen-only and dry-run always pass through
+- no keyDown/keyUp event taps were added
+
+## Manual Mac QA Steps
+Run locally on a real Mac with Accessibility and Input Monitoring permissions:
+
+```bash
+swift run ChromeWheelRouterCLI --active
+```
+
+1. In Chrome, hold Option and perform horizontal scroll right.
+   - Expected: page zooms in (Command + `=` behavior)
+   - Expected: original horizontal scroll is swallowed
+2. In Chrome, hold Option and perform horizontal scroll left.
+   - Expected: page zooms out (Command + `-` behavior)
+   - Expected: original horizontal scroll is swallowed
+3. Verify all non-matching inputs pass through unchanged:
+   - non-Chrome app
+   - vertical scroll
+   - no modifier
+   - Command/Shift/Control
+   - Option+Command
+4. Verify dry run never injects or swallows:
+
+```bash
+swift run ChromeWheelRouterCLI --dry-run
+```
+
+5. Verify listen-only never injects or swallows:
+
+```bash
+swift run ChromeWheelRouterCLI --listen-only
+```
+
+## Next Node
+Next node: **EXEC-05**.

--- a/project_memory/node_summaries/EXEC-04.md
+++ b/project_memory/node_summaries/EXEC-04.md
@@ -1,0 +1,7 @@
+# EXEC-04 Summary
+
+Implemented CLI active-mode zoom injection with guardrails:
+- added keyboard injection abstraction and CGEvent-based implementation for Command+= / Command+-
+- connected router decisions to event-tap outcomes through `EventAction`
+- enforced that listen-only and dry-run are always pass-through
+- enforced fail-open on runtime uncertainty by passing through when injection fails


### PR DESCRIPTION
### Motivation
- Implement the EXEC-04 goal: map Chrome + Option-only + horizontal scroll to Chrome zoom shortcuts and swallow the original scroll event in the CLI spike.
- Preserve the safety contract that only the precise match may be swallowed, and `--listen-only`/`--dry-run` must never inject or swallow.
- Keep event-tap callbacks free of blocking IO and keep the event tap mask limited to `scrollWheel` only.

### Description
- Add a `KeyboardInjecting` abstraction and a `CGKeyboardInjector` that posts Command+`=` (zoom in) and Command+`-` (zoom out) via `CGEvent` for macOS (`Sources/ChromeWheelRouterMac/KeyboardInjector.swift`).
- Introduce `EventAction` to centralize mode policy so `--active` may `injectAndSwallow` matching zoom decisions while `--listen-only` and `--dry-run` always `passThrough` (`Sources/ChromeWheelRouterMac/EventAction.swift`).
- Wire router decisions into the macOS adapter: `CGEventTapService` now consults `EventAction`, calls the injector on matching decisions, returns `nil` only when injection succeeds, and otherwise returns the original event (`Sources/ChromeWheelRouterMac/CGEventTapService.swift`).
- Add tests for the mode policy (`Tests/ChromeWheelRouterCoreTests/EventActionTests.swift`), update `Package.swift` test dependencies to allow the new tests, and add `node_reports/EXEC-04.md` plus a project-memory summary.

### Testing
- Ran `./scripts/check_all.sh`: static safety checks and harness validations passed (core routing tests were skipped on non-Darwin in that run). 
- Ran `swift test`: executed unit tests (14 tests) and they passed. 
- Ran `swift build -c release`: build completed successfully. 
- Static safety checks confirming only `scrollWheel` is observed and no keyboard event taps or forbidden APIs were introduced: PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19aedb9188323a81ca88697772803)