### PR TITLE
EXEC-05: add macOS menu bar MVP target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
         .executable(
             name: "ChromeWheelRouterCLI",
             targets: ["ChromeWheelRouterCLI"]
+        ),
+        .executable(
+            name: "ChromeWheelRouterApp",
+            targets: ["ChromeWheelRouterApp"]
         )
     ],
     targets: [
@@ -31,6 +35,10 @@ let package = Package(
         .executableTarget(
             name: "ChromeWheelRouterCLI",
             dependencies: ["ChromeWheelRouterCore", "ChromeWheelRouterMac"]
+        ),
+        .executableTarget(
+            name: "ChromeWheelRouterApp",
+            dependencies: ["ChromeWheelRouterMac"]
         ),
         .testTarget(
             name: "ChromeWheelRouterCoreTests",

--- a/Sources/ChromeWheelRouterApp/main.swift
+++ b/Sources/ChromeWheelRouterApp/main.swift
@@ -1,0 +1,147 @@
+#if canImport(AppKit)
+import AppKit
+import ApplicationServices
+import ChromeWheelRouterMac
+
+@main
+final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem!
+    private var statusMenu: NSMenu!
+
+    private var enabledMenuItem: NSMenuItem!
+    private var dryRunMenuItem: NSMenuItem!
+    private var statusMenuItem: NSMenuItem!
+
+    private var userEnabled = false
+    private var dryRunEnabled = false
+    private var tapService: CGEventTapService?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+        buildMenuBarUI()
+        reconcileRuntime()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        stopTapService()
+    }
+
+    private func buildMenuBarUI() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem.button?.title = "CWR"
+
+        statusMenu = NSMenu()
+
+        statusMenuItem = NSMenuItem(title: "Status: Starting...", action: nil, keyEquivalent: "")
+        statusMenuItem.isEnabled = false
+        statusMenu.addItem(statusMenuItem)
+
+        statusMenu.addItem(.separator())
+
+        enabledMenuItem = NSMenuItem(title: "Enable", action: #selector(toggleEnabled), keyEquivalent: "e")
+        enabledMenuItem.target = self
+        statusMenu.addItem(enabledMenuItem)
+
+        dryRunMenuItem = NSMenuItem(title: "Dry Run", action: #selector(toggleDryRun), keyEquivalent: "d")
+        dryRunMenuItem.target = self
+        dryRunMenuItem.state = .off
+        statusMenu.addItem(dryRunMenuItem)
+
+        statusMenu.addItem(.separator())
+
+        let openLogsItem = NSMenuItem(title: "Open Logs", action: #selector(openLogs), keyEquivalent: "l")
+        openLogsItem.target = self
+        statusMenu.addItem(openLogsItem)
+
+        statusMenu.addItem(.separator())
+
+        let quitItem = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
+        quitItem.target = self
+        statusMenu.addItem(quitItem)
+
+        statusItem.menu = statusMenu
+    }
+
+    @objc
+    private func toggleEnabled() {
+        userEnabled.toggle()
+        reconcileRuntime()
+    }
+
+    @objc
+    private func toggleDryRun() {
+        dryRunEnabled.toggle()
+        reconcileRuntime()
+    }
+
+    @objc
+    private func openLogs() {
+        let consoleURL = URL(fileURLWithPath: "/System/Applications/Utilities/Console.app")
+        NSWorkspace.shared.openApplication(at: consoleURL, configuration: NSWorkspace.OpenConfiguration()) { _, _ in }
+    }
+
+    @objc
+    private func quitApp() {
+        stopTapService()
+        NSApp.terminate(nil)
+    }
+
+    private func permissionsSatisfied() -> Bool {
+        AXIsProcessTrusted() && CGPreflightListenEventAccess()
+    }
+
+    private func reconcileRuntime() {
+        let hasPermissions = permissionsSatisfied()
+        let shouldRun = userEnabled && hasPermissions
+
+        if shouldRun {
+            let mode: EventTapMode = dryRunEnabled ? .dryRun : .active
+            restartTapService(mode: mode)
+        } else {
+            stopTapService()
+        }
+
+        refreshMenuState(hasPermissions: hasPermissions, running: shouldRun)
+    }
+
+    private func restartTapService(mode: EventTapMode) {
+        stopTapService()
+        let service = CGEventTapService(mode: mode)
+        if service.start() {
+            tapService = service
+        } else {
+            tapService = nil
+            userEnabled = false
+        }
+    }
+
+    private func stopTapService() {
+        tapService?.stop()
+        tapService = nil
+    }
+
+    private func refreshMenuState(hasPermissions: Bool, running: Bool) {
+        enabledMenuItem.state = userEnabled ? .on : .off
+        enabledMenuItem.title = userEnabled ? "Disable" : "Enable"
+        dryRunMenuItem.state = dryRunEnabled ? .on : .off
+
+        if running {
+            statusMenuItem.title = dryRunEnabled ? "Status: Running (Dry Run)" : "Status: Running"
+        } else if !hasPermissions {
+            statusMenuItem.title = "Status: Missing Accessibility/Input Monitoring"
+        } else {
+            statusMenuItem.title = "Status: Disabled"
+        }
+    }
+}
+#else
+import Foundation
+
+@main
+struct ChromeWheelRouterApp {
+    static func main() {
+        fputs("ChromeWheelRouterApp is only supported on macOS.\n", stderr)
+        Foundation.exit(1)
+    }
+}
+#endif

--- a/Sources/ChromeWheelRouterMac/CGEventTapService.swift
+++ b/Sources/ChromeWheelRouterMac/CGEventTapService.swift
@@ -24,6 +24,10 @@ public final class CGEventTapService {
     }
 
     public func start() -> Bool {
+        guard eventTap == nil else {
+            return true
+        }
+
         let mask = CGEventMask(1 << CGEventType.scrollWheel.rawValue)
         let callback: CGEventTapCallBack = { proxy, type, event, context in
             guard let context else { return Unmanaged.passUnretained(event) }
@@ -48,6 +52,19 @@ public final class CGEventTapService {
         CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         return true
+    }
+
+    public func stop() {
+        guard let tap = eventTap else {
+            return
+        }
+
+        CGEvent.tapEnable(tap: tap, enable: false)
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        runLoopSource = nil
+        eventTap = nil
     }
 
     public func run() {
@@ -112,6 +129,8 @@ public final class CGEventTapService {
     public func start() -> Bool {
         false
     }
+
+    public func stop() {}
 
     public func run() {}
 }

--- a/node_reports/EXEC-05.md
+++ b/node_reports/EXEC-05.md
@@ -1,0 +1,44 @@
+# EXEC-05 Node Report — Menu Bar MVP
+
+Date: 2026-04-29
+Branch: codex/exec-05
+
+## Scope
+Implemented a minimal macOS menu bar app target that reuses the existing event-tap/router pipeline:
+- added `ChromeWheelRouterApp` executable target
+- added menu bar UI entries:
+  - Status
+  - Enable / Disable
+  - Dry Run
+  - Open Logs
+  - Quit
+- app now starts disabled by default
+- runtime starts event tap only when:
+  - user has enabled router
+  - Accessibility and Input Monitoring preflight checks pass
+- menu `Quit` action explicitly stops the event tap before termination
+- kept `ChromeWheelRouterCLI` target unchanged for debugging workflows
+
+## Commands Run
+1. `swift test`
+2. `swift build -c release`
+3. `./scripts/check_all.sh`
+
+## Results
+- `swift test`: PASS
+- `swift build -c release`: PASS
+- `./scripts/check_all.sh`: PASS
+
+## Safety Confirmation
+- no new event tap kinds were added; `scrollWheel` remains the only tap mask
+- disable path stops event tap service, resulting in full pass-through
+- quit path stops event tap service before process exit
+- no keyDown/keyUp listeners were introduced
+- no new permissions beyond Accessibility/Input Monitoring were introduced
+
+## Notes
+- Start at Login intentionally not included in EXEC-05 per node constraints.
+- Installer/package work intentionally not included in EXEC-05 per node constraints.
+
+## Next Node
+Next node: **EXEC-06**.

--- a/project_memory/node_summaries/EXEC-05.md
+++ b/project_memory/node_summaries/EXEC-05.md
@@ -1,0 +1,9 @@
+# EXEC-05 Summary
+
+Date: 2026-04-29
+
+- Added `ChromeWheelRouterApp` executable target as a menu bar MVP.
+- Implemented menu actions for status, enable/disable, dry run toggle, open logs, and quit.
+- App starts disabled and only starts event tap when both user enablement and permission preflight are satisfied.
+- Added explicit `CGEventTapService.stop()` and used it on disable and quit paths to guarantee pass-through when disabled.
+- Preserved CLI target for debugging and regression isolation.


### PR DESCRIPTION
### Motivation
- Turn the CLI spike into a minimal macOS menu bar MVP that reuses the existing routing/event-tap pipeline and provides simple runtime controls. 
- Provide safe user controls (Enable/Disable, Dry Run, Status, Open Logs, Quit) and ensure the event tap is only started when both user enablement and Accessibility/Input Monitoring preflight checks succeed. 
- Keep the change small and reviewable while preserving the CLI for debugging and honoring the node constraints (no Start at Login, no installer, no extra permissions). 

### Description
- Add a new executable product/target `ChromeWheelRouterApp` in `Package.swift`. 
- Implement a minimal menu bar app in `Sources/ChromeWheelRouterApp/main.swift` with Status, `Enable`/`Disable`, `Dry Run`, `Open Logs`, and `Quit` items and logic that starts/stops the event tap based on user toggles and permission preflight. 
- Make `CGEventTapService` idempotent on `start()` and add a `stop()` method to explicitly tear down the tap for full pass-through when disabled or quitting (`Sources/ChromeWheelRouterMac/CGEventTapService.swift`). 
- Preserve the existing `ChromeWheelRouterCLI` target and add `node_reports/EXEC-05.md` and `project_memory/node_summaries/EXEC-05.md` documenting the change. 

### Testing
- Ran `swift test`, which executed the `EventActionTests` and `RouterTests` and completed with all tests passing. 
- Built with `swift build -c release` and ran the project checks with `./scripts/check_all.sh`, and all automated checks reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19c351d308323a96638131ab8e22b)