### PR TITLE
EXEC-06: Permission UX and fail-closed runtime gating

### DIFF
--- a/Sources/ChromeWheelRouterApp/main.swift
+++ b/Sources/ChromeWheelRouterApp/main.swift
@@ -11,6 +11,7 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
     private var enabledMenuItem: NSMenuItem!
     private var dryRunMenuItem: NSMenuItem!
     private var statusMenuItem: NSMenuItem!
+    private var permissionMenuItem: NSMenuItem!
 
     private var userEnabled = false
     private var dryRunEnabled = false
@@ -36,6 +37,10 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
         statusMenuItem.isEnabled = false
         statusMenu.addItem(statusMenuItem)
 
+        permissionMenuItem = NSMenuItem(title: "Permissions: Checking...", action: nil, keyEquivalent: "")
+        permissionMenuItem.isEnabled = false
+        statusMenu.addItem(permissionMenuItem)
+
         statusMenu.addItem(.separator())
 
         enabledMenuItem = NSMenuItem(title: "Enable", action: #selector(toggleEnabled), keyEquivalent: "e")
@@ -48,6 +53,14 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
         statusMenu.addItem(dryRunMenuItem)
 
         statusMenu.addItem(.separator())
+
+        let openAccessibilityItem = NSMenuItem(title: "Open Accessibility Settings", action: #selector(openAccessibilitySettings), keyEquivalent: "a")
+        openAccessibilityItem.target = self
+        statusMenu.addItem(openAccessibilityItem)
+
+        let openInputMonitoringItem = NSMenuItem(title: "Open Input Monitoring Settings", action: #selector(openInputMonitoringSettings), keyEquivalent: "i")
+        openInputMonitoringItem.target = self
+        statusMenu.addItem(openInputMonitoringItem)
 
         let openLogsItem = NSMenuItem(title: "Open Logs", action: #selector(openLogs), keyEquivalent: "l")
         openLogsItem.target = self
@@ -75,6 +88,16 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
     }
 
     @objc
+    private func openAccessibilitySettings() {
+        openPrivacySettingsPane(anchor: "Privacy_Accessibility")
+    }
+
+    @objc
+    private func openInputMonitoringSettings() {
+        openPrivacySettingsPane(anchor: "Privacy_ListenEvent")
+    }
+
+    @objc
     private func openLogs() {
         let consoleURL = URL(fileURLWithPath: "/System/Applications/Utilities/Console.app")
         NSWorkspace.shared.openApplication(at: consoleURL, configuration: NSWorkspace.OpenConfiguration()) { _, _ in }
@@ -84,6 +107,16 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
     private func quitApp() {
         stopTapService()
         NSApp.terminate(nil)
+    }
+
+    private func openPrivacySettingsPane(anchor: String) {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?") else {
+            return
+        }
+        let fullURL = URL(string: "\(url.absoluteString)\(anchor)")
+        if let fullURL {
+            NSWorkspace.shared.open(fullURL)
+        }
     }
 
     private func permissionsSatisfied() -> Bool {
@@ -125,10 +158,12 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
         enabledMenuItem.title = userEnabled ? "Disable" : "Enable"
         dryRunMenuItem.state = dryRunEnabled ? .on : .off
 
+        permissionMenuItem.title = hasPermissions ? "Permissions: Granted" : "Permissions: Missing"
+
         if running {
             statusMenuItem.title = dryRunEnabled ? "Status: Running (Dry Run)" : "Status: Running"
         } else if !hasPermissions {
-            statusMenuItem.title = "Status: Missing Accessibility/Input Monitoring"
+            statusMenuItem.title = "Status: Missing Permissions"
         } else {
             statusMenuItem.title = "Status: Disabled"
         }

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,5 +1,21 @@
 # Troubleshooting
 
+## Missing permissions status in menu
+
+If the menu bar app shows `Status: Missing Permissions` or `Permissions: Missing`, ChromeWheelRouter is intentionally fail-closed and will **not** create the active event tap.
+
+Grant both permissions in System Settings:
+
+- Privacy & Security → Accessibility
+- Privacy & Security → Input Monitoring
+
+You can use these menu actions directly from ChromeWheelRouter:
+
+- Open Accessibility Settings
+- Open Input Monitoring Settings
+
+After granting access, quit and relaunch the app.
+
 ## Bare horizontal wheel stopped working in Chrome
 
 Expected code behavior is pass-through. Check:
@@ -19,10 +35,3 @@ Possible future fallback:
   - Option + horizontal wheel → zoom
 
 This is not the default MVP because the user asked to preserve Logi Options+ behavior.
-
-## Permissions do not appear
-
-Quit and reopen the app. If still missing, open System Settings manually:
-
-- Privacy & Security → Input Monitoring
-- Privacy & Security → Accessibility

--- a/node_reports/EXEC-06.md
+++ b/node_reports/EXEC-06.md
@@ -1,0 +1,35 @@
+# EXEC-06 Node Report — Permission UX and Fail-Closed
+
+Date: 2026-04-29
+Branch: codex/exec-06
+
+## Scope
+Implemented permission UX so missing permissions are visible and safe:
+- added explicit permission status menu row (`Permissions: Granted` / `Permissions: Missing`)
+- added menu actions:
+  - Open Accessibility Settings
+  - Open Input Monitoring Settings
+- ensured runtime remains fail-closed when permissions are missing:
+  - active event tap is not started
+  - existing tap is stopped when permission state is missing
+- updated troubleshooting guidance with direct permission recovery steps
+
+## Commands Run
+1. `swift test`
+2. `swift build -c release`
+3. `./scripts/check_all.sh`
+
+## Results
+- `swift test`: PASS
+- `swift build -c release`: PASS
+- `./scripts/check_all.sh`: PASS
+
+## Safety Confirmation
+- no TCC/privacy bypasses were implemented
+- no additional permissions were requested
+- no keyDown/keyUp listeners were introduced
+- event tap creation remains contingent on permissions in app runtime
+- missing permissions path is non-crashing and fail-closed
+
+## Next Node
+Next node: **EXEC-07**.

--- a/project_memory/node_summaries/EXEC-06.md
+++ b/project_memory/node_summaries/EXEC-06.md
@@ -1,0 +1,6 @@
+# EXEC-06 Summary
+
+- Added explicit permission visibility in the menu bar UI.
+- Added direct settings shortcuts for Accessibility and Input Monitoring.
+- Preserved fail-closed behavior: missing permissions prevent active event tap startup.
+- Updated troubleshooting documentation for permission recovery steps.


### PR DESCRIPTION
### Motivation
- Make permission handling visible and safe so the app does not create an active event tap when required TCC permissions are missing.
- Provide direct recovery actions in the menu so users can open the correct macOS privacy panes for Accessibility and Input Monitoring.
- Fail-closed on missing permissions to avoid unsafe partial behavior and to keep event handling scoped to `scrollWheel` only.

### Description
- Added a dedicated permission status row to the menu UI (`Permissions: Granted` / `Permissions: Missing`) in `Sources/ChromeWheelRouterApp/main.swift` and adjusted status messaging to `Status: Missing Permissions` when appropriate.
- Added menu actions `Open Accessibility Settings` and `Open Input Monitoring Settings` that open the relevant System Settings panes via `x-apple.systempreferences` URLs implemented in `openPrivacySettingsPane(anchor:)`.
- Ensured runtime gating remains fail-closed so the event tap is not started when `permissionsSatisfied()` (using `AXIsProcessTrusted()` and `CGPreflightListenEventAccess()`) returns false and any running tap is stopped via `stopTapService()`.
- Updated `TROUBLESHOOTING.md` with explicit guidance for the new permission UI and recovery steps, and added `node_reports/EXEC-06.md` and `project_memory/node_summaries/EXEC-06.md` to record the node work.

### Testing
- Ran `swift test` and all unit tests passed (14 tests, 0 failures).
- Built production with `swift build -c release` which completed successfully.
- Executed `./scripts/check_all.sh` which completed and reported all checks OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19d82f0fc832399939b4c28a50a01)