### PR TITLE
Add idempotent developer install/uninstall scripts (EXEC-08)

### DIFF
--- a/node_reports/EXEC-08.md
+++ b/node_reports/EXEC-08.md
@@ -1,0 +1,50 @@
+# EXEC-08 Node Report — Dev Install / Uninstall
+
+Date: 2026-04-29
+Branch: codex/exec-08
+
+## Scope
+Implemented developer install/uninstall scripts for local owner testing with strict user-level paths and no privileged operations:
+- added `scripts/install_dev.sh` with release build + install flow
+- added `scripts/uninstall_dev.sh` with cleanup flow for installed artifacts
+- both scripts support dry-run mode and are idempotent
+
+## Install behavior
+- installs only to user-controlled directories:
+  - `~/Library/Application Support/ChromeWheelRouter/bin/ChromeWheelRouterApp`
+  - `~/Applications/ChromeWheelRouter.command`
+  - `~/Library/Logs/ChromeWheelRouter` (directory only)
+- writes install metadata to:
+  - `~/Library/Application Support/ChromeWheelRouter/install-meta.txt`
+
+## Uninstall behavior
+- attempts to stop running ChromeWheelRouter process (best effort)
+- removes:
+  - `~/Applications/ChromeWheelRouter.command`
+  - `~/Library/Application Support/ChromeWheelRouter`
+  - `~/Library/Logs/ChromeWheelRouter`
+- operation is idempotent; missing paths are ignored
+
+## Safety Constraints Confirmation
+- no `sudo`
+- no writes to `/System`
+- no writes to `/Library/LaunchDaemons`
+- no privileged helpers
+- no Chrome or Logi Options+ config modifications
+
+## Privacy Permission Note
+Both scripts document that Accessibility/Input Monitoring permissions must be revoked manually in macOS System Settings.
+
+## Commands Run
+1. `bash -n scripts/install_dev.sh`
+2. `bash -n scripts/uninstall_dev.sh`
+3. `./scripts/install_dev.sh --dry-run --skip-build`
+4. `./scripts/uninstall_dev.sh --dry-run`
+5. `./scripts/check_all.sh`
+
+## Results
+- all commands: PASS
+
+## Notes
+- Hardware/input-device QA remains required on a real Mac.
+- Next node is **EXEC-09**.

--- a/project_memory/node_summaries/EXEC-08.md
+++ b/project_memory/node_summaries/EXEC-08.md
@@ -1,0 +1,3 @@
+# EXEC-08 Summary
+
+Implemented clean developer install/uninstall scripts for local testing using only user-owned paths. `install_dev.sh` now supports release build install, dry-run/verbose modes, and metadata capture; `uninstall_dev.sh` supports dry-run/verbose, best-effort process stop, and idempotent removal of launcher, app support, and logs. Both scripts explicitly document manual macOS privacy permission revocation.

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -1,8 +1,105 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Placeholder for the future app-based installer.
-# Current scaffold has only a Swift package core and no .app yet.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-echo "No installable app exists yet. Run scripts/build.sh to validate the scaffold."
-echo "Once the menu bar app exists, this script should install to ~/Applications, not system locations."
+DRY_RUN=0
+VERBOSE=0
+SKIP_BUILD=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/install_dev.sh [--dry-run] [--verbose] [--skip-build] [--help]
+
+Installs ChromeWheelRouter developer artifacts to user-owned locations only:
+- ~/Applications
+- ~/Library/Application Support/ChromeWheelRouter
+
+Options:
+  -n, --dry-run    Print actions without changing files
+  -v, --verbose    Print detailed command progress
+      --skip-build Skip swift build -c release
+  -h, --help       Show this help
+USAGE
+}
+
+log() { echo "$*"; }
+verbose() { [[ "$VERBOSE" -eq 1 ]] && echo "[verbose] $*"; }
+run_cmd() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] $*"
+  else
+    verbose "$*"
+    "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--dry-run) DRY_RUN=1 ;;
+    -v|--verbose) VERBOSE=1 ;;
+    --skip-build) SKIP_BUILD=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+  shift
+done
+
+APP_NAME="ChromeWheelRouterApp"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/ChromeWheelRouter"
+BIN_DIR="$APP_SUPPORT_DIR/bin"
+LOG_DIR="$HOME/Library/Logs/ChromeWheelRouter"
+USER_APPS_DIR="$HOME/Applications"
+LAUNCHER_PATH="$USER_APPS_DIR/ChromeWheelRouter.command"
+INSTALL_META="$APP_SUPPORT_DIR/install-meta.txt"
+BUILD_BIN="$REPO_ROOT/.build/release/$APP_NAME"
+INSTALLED_BIN="$BIN_DIR/$APP_NAME"
+
+log "Installing ChromeWheelRouter developer build to user-owned locations."
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  run_cmd swift build -c release --product "$APP_NAME" --package-path "$REPO_ROOT"
+else
+  log "Skipping build because --skip-build was provided."
+fi
+
+if [[ ! -x "$BUILD_BIN" ]]; then
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] would require built binary at: $BUILD_BIN"
+  else
+    echo "Expected built binary at: $BUILD_BIN" >&2
+    echo "Build first or remove --skip-build." >&2
+    exit 1
+  fi
+fi
+
+run_cmd mkdir -p "$USER_APPS_DIR" "$BIN_DIR" "$LOG_DIR"
+run_cmd cp "$BUILD_BIN" "$INSTALLED_BIN"
+run_cmd chmod 755 "$INSTALLED_BIN"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] write launcher at $LAUNCHER_PATH"
+else
+  cat > "$LAUNCHER_PATH" <<LAUNCHER
+#!/usr/bin/env bash
+exec "$INSTALLED_BIN" "\$@"
+LAUNCHER
+  chmod 755 "$LAUNCHER_PATH"
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] write install metadata at $INSTALL_META"
+else
+  {
+    echo "installed_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "source_repo=$REPO_ROOT"
+    echo "binary=$INSTALLED_BIN"
+    echo "launcher=$LAUNCHER_PATH"
+  } > "$INSTALL_META"
+fi
+
+log "Install complete."
+log "Installed binary: $INSTALLED_BIN"
+log "Launcher: $LAUNCHER_PATH"
+log "Note: macOS Accessibility/Input Monitoring permissions, if granted, must be revoked manually in System Settings."

--- a/scripts/uninstall_dev.sh
+++ b/scripts/uninstall_dev.sh
@@ -1,16 +1,51 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_PATH="$HOME/Applications/ChromeWheelRouter.app"
-CONFIG_PATH="$HOME/Library/Application Support/ChromeWheelRouter"
-LOG_PATH="$HOME/Library/Logs/ChromeWheelRouter"
+DRY_RUN=0
+VERBOSE=0
 
-echo "Stopping ChromeWheelRouter if running..."
-pkill -f "ChromeWheelRouter" 2>/dev/null || true
+usage() {
+  cat <<'USAGE'
+Usage: scripts/uninstall_dev.sh [--dry-run] [--verbose] [--help]
 
-rm -rf "$APP_PATH"
-rm -rf "$CONFIG_PATH"
-rm -rf "$LOG_PATH"
+Removes ChromeWheelRouter developer install artifacts from user-owned locations:
+- ~/Applications/ChromeWheelRouter.command
+- ~/Library/Application Support/ChromeWheelRouter
+- ~/Library/Logs/ChromeWheelRouter
 
-echo "Removed user-level ChromeWheelRouter files where present."
-echo "If macOS permissions were granted, revoke them manually in System Settings → Privacy & Security."
+This script does not and cannot revoke macOS privacy permissions automatically.
+USAGE
+}
+
+verbose() { [[ "$VERBOSE" -eq 1 ]] && echo "[verbose] $*"; }
+run_cmd() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] $*"
+  else
+    verbose "$*"
+    "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--dry-run) DRY_RUN=1 ;;
+    -v|--verbose) VERBOSE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+  shift
+done
+
+APP_COMMAND="$HOME/Applications/ChromeWheelRouter.command"
+APP_SUPPORT_DIR="$HOME/Library/Application Support/ChromeWheelRouter"
+LOG_DIR="$HOME/Library/Logs/ChromeWheelRouter"
+
+echo "Uninstalling ChromeWheelRouter developer artifacts..."
+run_cmd pkill -f "ChromeWheelRouter(App|CLI)?" || true
+run_cmd rm -f "$APP_COMMAND"
+run_cmd rm -rf "$APP_SUPPORT_DIR"
+run_cmd rm -rf "$LOG_DIR"
+
+echo "Uninstall complete (idempotent: missing paths are ignored)."
+echo "If granted previously, revoke Accessibility/Input Monitoring permissions manually in System Settings → Privacy & Security."


### PR DESCRIPTION
### Motivation
- Provide a clean, user-only developer install/uninstall flow for local testing without requiring elevated privileges or writing to system locations. 
- Ensure installs are idempotent, support dry-run/verbose modes, and document that macOS privacy permissions must be revoked manually. 
- Constrain behavior to the safety rules (no `sudo`, no `/System` or `/Library/LaunchDaemons` writes, no privileged helpers). 

### Description
- Add `scripts/install_dev.sh` which builds `ChromeWheelRouterApp` by default (unless `--skip-build`), installs the binary to `~/Library/Application Support/ChromeWheelRouter/bin/`, creates a launcher at `~/Applications/ChromeWheelRouter.command`, and writes install metadata to `~/Library/Application Support/ChromeWheelRouter/install-meta.txt`, with `--dry-run` and `--verbose` support. 
- Add `scripts/uninstall_dev.sh` which best-effort stops running processes, removes the launcher, app support directory, and logs directory idempotently, and supports `--dry-run` and `--verbose`. 
- Add `node_reports/EXEC-08.md` documenting scope, constraints, commands run, and results. 

### Testing
- Ran static checks: `bash -n scripts/install_dev.sh` and `bash -n scripts/uninstall_dev.sh`, both succeeded. 
- Exercised installer/uninstaller dry runs: `./scripts/install_dev.sh --dry-run --skip-build` and `./scripts/uninstall_dev.sh --dry-run`, and observed expected dry-run output. 
- Ran the repository validation: `./scripts/check_all.sh`, which completed successfully and included the unit test run (14 tests) and build steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a0176c6c8323b34e720adaba334c)