### PR TITLE
[codex] Fix release asset upload workflow

### DIFF
--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -89,12 +89,13 @@ jobs:
       - name: Create or update release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
           ls -la release-assets
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release upload "$TAG" release-assets/* --clobber
+          if gh release view "$TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG" release-assets/* --clobber --repo "$GH_REPO"
           else
-            gh release create "$TAG" release-assets/* --title "$TAG" --generate-notes --verify-tag
+            gh release create "$TAG" release-assets/* --title "$TAG" --generate-notes --verify-tag --repo "$GH_REPO"
           fi

--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -30,10 +32,17 @@ jobs:
         run: swift --version
 
       - name: Build dist package
-        env:
-          VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || format('pr-{0}-{1}', github.event.pull_request.number, github.run_number) }}
         run: |
           set -euo pipefail
+          if [ '${{ github.event_name }}' = 'release' ]; then
+            VERSION='${{ github.event.release.tag_name }}'
+          elif [ '${{ github.ref_type }}' = 'tag' ]; then
+            VERSION='${{ github.ref_name }}'
+          elif [ '${{ github.event_name }}' = 'pull_request' ]; then
+            VERSION='pr-${{ github.event.pull_request.number }}-${{ github.run_number }}'
+          else
+            VERSION='run-${{ github.run_number }}'
+          fi
           VERSION="${VERSION#v}" ./scripts/package_rc.sh
 
       - name: Verify dist artifact set
@@ -51,9 +60,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          safe_ref="$(printf '%s' '${{ github.ref_name }}' | tr '/:' '--')"
-          tar -czf "release-assets/dist-${safe_ref}-${{ github.run_number }}.tar.gz" -C dist .
-          shasum -a 256 release-assets/* > release-assets/SHA256SUMS.txt
+          cp dist/* release-assets/
+          (cd release-assets && shasum -a 256 * > RELEASE_ASSET_SHA256SUMS.txt)
           ls -la release-assets
 
       - name: Upload dist workflow artifact
@@ -66,7 +74,7 @@ jobs:
 
   release:
     name: Create or update GitHub Release
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'release' }}
     needs: build
     runs-on: macos-latest
     permissions:
@@ -81,7 +89,7 @@ jobs:
       - name: Create or update release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
           ls -la release-assets


### PR DESCRIPTION
## Summary

- Uploads the built DMG and dist metadata files directly as GitHub Release assets instead of wrapping them in a tarball.
- Adds a `release: published` trigger so releases created from the GitHub UI can run the asset workflow.
- Passes `--repo $GH_REPO` to all `gh release` commands so the artifact-only release job does not fail with `fatal: not a git repository`.

## Validation

- `.github/workflows/release-dist.yml` parses as YAML.
- Branch diff against `origin/main` is limited to `.github/workflows/release-dist.yml`.

## Notes

The failed run used the previous workflow and uploaded `dist-v0.0.2-4.tar.gz`; after this change, release uploads should include the `.dmg` as a first-class release asset.