### PR TITLE
[codex] Fix event tap hot path performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ These rules are non-negotiable.
 28. Event tap callbacks must not take blocking locks.
 29. If permissions are missing, fail closed: do not create the event tap.
 30. If runtime state is uncertain, fail open: pass events through.
+31. Event tap callbacks must stay allocation-light and must not perform per-event logging.
+32. Long-running runtime polling must not recreate event taps unless the desired running state or mode changed.
+33. Frontmost-app state should be cached outside the event tap callback when practical; do not add repeated workspace/process lookups to the hot path without a documented reason.
 
 ## Target implementation shape
 

--- a/ChromeWheelRouter/docs/development/project_memory/decisions/ADR-004-event-tap-hot-path-performance-guardrails.md
+++ b/ChromeWheelRouter/docs/development/project_memory/decisions/ADR-004-event-tap-hot-path-performance-guardrails.md
@@ -1,0 +1,26 @@
+# ADR-004 - Event tap hot path performance guardrails
+
+## Status
+
+Accepted
+
+## Context
+
+User testing observed visible pointer latency while ChromeWheelRouter was enabled, especially when moving the pointer between displays. Review found that the app recreated the global scroll event tap from periodic status polling and logged every scroll event from inside the event tap callback.
+
+Even though the app subscribes only to `scrollWheel`, blocking or repeatedly disturbing global event tap plumbing can create broader input-system pressure.
+
+## Decision
+
+ChromeWheelRouter treats event tap performance regressions as safety regressions.
+
+The event tap callback must not perform per-event logging, disk IO, stdout/stderr IO, shell commands, sleeps, blocking waits, or avoidable workspace/process lookups. Runtime polling must be idempotent and must not recreate, restart, or re-enable event taps unless the desired running state or mode changed.
+
+Frontmost-app state should be cached outside the callback when practical and passed into the event adapter as cheap state.
+
+## Consequences
+
+- Diagnostic logging from the scroll path must be sampled, aggregated, or moved outside the callback.
+- Static safety checks should reject hot-path logging or file/stdout IO in `CGEventTapService`.
+- Manual QA for releases should include long-running enabled state, scroll bursts, and multi-display pointer movement.
+- Future permission/status polling changes must prove they do not churn event taps in steady state.

--- a/ChromeWheelRouter/docs/development/project_memory/lessons_learned/2026-04-30-event-tap-hot-path-performance.md
+++ b/ChromeWheelRouter/docs/development/project_memory/lessons_learned/2026-04-30-event-tap-hot-path-performance.md
@@ -1,0 +1,25 @@
+# 2026-04-30 - Event tap hot path performance
+
+## Context
+
+User testing observed visible pointer latency while ChromeWheelRouter was running, especially when moving the pointer between displays. Review found two long-running performance hazards:
+
+- status polling recreated the global scroll event tap every second while enabled
+- every scroll event was logged from inside the event tap callback, which routed to synchronous disk IO in the app
+
+## Lesson
+
+The scroll event tap callback must stay allocation-light and free of logging, disk IO, process/workspace polling, shelling out, sleeps, and blocking waits. Long-running status polling must be idempotent and must not churn event taps unless the desired running state or mode changed.
+
+Pointer latency can surface even though the tap only subscribes to `scrollWheel`, because repeatedly disturbing global event tap plumbing or blocking the callback can create broader input-system pressure.
+
+## Follow-up
+
+Keep static checks in place for hot-path logging/IO in `CGEventTapService`.
+
+Manual QA should include:
+
+- enable the app and leave it running for several minutes
+- move the pointer rapidly between displays
+- perform burst horizontal and vertical wheel input
+- confirm the pointer remains responsive and scroll routing still follows the MVP contract

--- a/ChromeWheelRouter/docs/product/TROUBLESHOOTING.md
+++ b/ChromeWheelRouter/docs/product/TROUBLESHOOTING.md
@@ -16,6 +16,19 @@ You can use these menu actions directly from ChromeWheelRouter:
 
 After granting access, quit and relaunch the app.
 
+## Pointer or mouse movement feels delayed
+
+Disable ChromeWheelRouter from the menu bar and check whether pointer latency immediately disappears.
+
+If latency only occurs while enabled, collect:
+
+- macOS version
+- display count and arrangement
+- mouse model and Logi Options+ version if applicable
+- whether latency happens during scroll bursts, display crossing, or both
+
+The event tap must not perform per-event logging or disk IO, and the app must not repeatedly recreate the tap while running. These are performance safety invariants and regressions should be treated as release blockers.
+
 ## Bare horizontal wheel stopped working in Chrome
 
 Expected code behavior is pass-through. Check:

--- a/ChromeWheelRouter/docs/specs/safety_invariants.md
+++ b/ChromeWheelRouter/docs/specs/safety_invariants.md
@@ -40,6 +40,14 @@ The event callback must not perform:
 - blocking waits
 - package installation
 - config mutation
+- per-event logging
+- repeated workspace/process lookups when equivalent state can be cached outside the callback
+
+## Long-running runtime constraints
+
+- Runtime polling must not restart, recreate, or re-enable event taps unless the desired running state or mode changed.
+- Permission/status checks must stay outside the scroll event callback.
+- Diagnostics for scroll events must be sampled, aggregated, or moved off the event tap hot path.
 
 ## Installation constraints
 

--- a/Sources/ChromeWheelRouterApp/main.swift
+++ b/Sources/ChromeWheelRouterApp/main.swift
@@ -27,6 +27,9 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
     private var userEnabled = false
     private var dryRunEnabled = false
     private var tapService: CGEventTapService?
+    private var currentTapMode: EventTapMode?
+    private var cachedFrontmostBundleID: String = "unknown"
+    private var frontmostApplicationObserver: NSObjectProtocol?
     private var statusPollTimer: Timer?
     private var startupHeartbeatTimer: Timer?
 
@@ -47,6 +50,7 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         ensureAppSupportDirectory()
         appendLog("Application launched. bundlePath=\(Bundle.main.bundlePath)")
+        startFrontmostApplicationCache()
         buildMenuBarUI()
         appendLog("Status item created.")
         startStatusPolling()
@@ -59,6 +63,10 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
         statusPollTimer = nil
         startupHeartbeatTimer?.invalidate()
         startupHeartbeatTimer = nil
+        if let frontmostApplicationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(frontmostApplicationObserver)
+        }
+        frontmostApplicationObserver = nil
         stopTapService()
     }
 
@@ -233,6 +241,24 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
         AXIsProcessTrusted() && CGPreflightListenEventAccess()
     }
 
+    private func startFrontmostApplicationCache() {
+        cachedFrontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+        frontmostApplicationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard
+                let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                let bundleIdentifier = app.bundleIdentifier
+            else {
+                self?.cachedFrontmostBundleID = "unknown"
+                return
+            }
+            self?.cachedFrontmostBundleID = bundleIdentifier
+        }
+    }
+
     private func reconcileRuntime() {
         if killSwitchPresent() {
             if userEnabled {
@@ -246,7 +272,7 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
 
         if shouldRun {
             let mode: EventTapMode = dryRunEnabled ? .dryRun : .active
-            restartTapService(mode: mode)
+            startTapServiceIfNeeded(mode: mode)
         } else {
             stopTapService()
         }
@@ -254,23 +280,27 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
         refreshMenuState(hasPermissions: hasPermissions, running: shouldRun)
     }
 
-    private func restartTapService(mode: EventTapMode) {
+    private func startTapServiceIfNeeded(mode: EventTapMode) {
+        if tapService != nil && currentTapMode == mode {
+            return
+        }
+
         stopTapService()
         let service = CGEventTapService(
             mode: mode,
             isEnabled: { [weak self] in self?.userEnabled == true },
+            frontmostBundleID: { [weak self] in self?.cachedFrontmostBundleID ?? "unknown" },
             onTapDisabled: { [weak self] reason in
                 self?.appendLog("Event tap temporarily disabled: \(reason).")
-            },
-            logger: { [weak self] line in
-                self?.appendLog(line)
             }
         )
         if service.start() {
             tapService = service
+            currentTapMode = mode
             appendLog("Event tap started in mode=\(mode.rawValue).")
         } else {
             tapService = nil
+            currentTapMode = nil
             userEnabled = false
             appendLog("Failed to start event tap. Disabling app.")
         }
@@ -282,6 +312,7 @@ final class ChromeWheelRouterApp: NSObject, NSApplicationDelegate {
             appendLog("Event tap stopped.")
         }
         tapService = nil
+        currentTapMode = nil
     }
 
     private func refreshMenuState(hasPermissions: Bool, running: Bool) {

--- a/Sources/ChromeWheelRouterMac/CGEventTapService.swift
+++ b/Sources/ChromeWheelRouterMac/CGEventTapService.swift
@@ -12,9 +12,9 @@ public final class CGEventTapService {
     private let router: Router
     private let mode: EventTapMode
     private let isEnabled: () -> Bool
+    private let frontmostBundleID: () -> String
     private let keyboardInjector: KeyboardInjecting
     private let onTapDisabled: ((EventTapDisableReason) -> Void)?
-    private let logger: (String) -> Void
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
@@ -22,16 +22,18 @@ public final class CGEventTapService {
         router: Router = Router(),
         mode: EventTapMode,
         isEnabled: @escaping () -> Bool = { true },
+        frontmostBundleID: @escaping () -> String = {
+            NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+        },
         keyboardInjector: KeyboardInjecting = CGKeyboardInjector(),
-        onTapDisabled: ((EventTapDisableReason) -> Void)? = nil,
-        logger: @escaping (String) -> Void = { print($0) }
+        onTapDisabled: ((EventTapDisableReason) -> Void)? = nil
     ) {
         self.router = router
         self.mode = mode
         self.isEnabled = isEnabled
+        self.frontmostBundleID = frontmostBundleID
         self.keyboardInjector = keyboardInjector
         self.onTapDisabled = onTapDisabled
-        self.logger = logger
     }
 
     public func start() -> Bool {
@@ -100,16 +102,13 @@ public final class CGEventTapService {
             return Unmanaged.passUnretained(event)
         }
 
-        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
         let model = ScrollEventAdapter.makeModel(
             event: event,
-            frontmostBundleID: frontmostBundleID,
+            frontmostBundleID: frontmostBundleID(),
             routerEnabled: isEnabled()
         )
         let decision = router.decide(model)
         let action = EventAction.forMode(mode, decision: decision)
-
-        log(decision: decision, model: model, action: action)
 
         guard action == .injectAndSwallow else {
             return Unmanaged.passUnretained(event)
@@ -131,10 +130,6 @@ public final class CGEventTapService {
 
         return injected ? nil : Unmanaged.passUnretained(event)
     }
-
-    private func log(decision: RouteDecision, model: ScrollEventModel, action: EventAction) {
-        logger("mode=\(mode.rawValue) app=\(model.frontmostBundleID) dx=\(model.horizontalDelta) dy=\(model.verticalDelta) decision=\(decision) action=\(action)")
-    }
 }
 #else
 import ChromeWheelRouterCore
@@ -149,9 +144,9 @@ public final class CGEventTapService {
         router: Router = Router(),
         mode: EventTapMode,
         isEnabled: @escaping () -> Bool = { true },
+        frontmostBundleID: @escaping () -> String = { "unknown" },
         keyboardInjector: KeyboardInjecting = CGKeyboardInjector(),
-        onTapDisabled: ((EventTapDisableReason) -> Void)? = nil,
-        logger: @escaping (String) -> Void = { _ in }
+        onTapDisabled: ((EventTapDisableReason) -> Void)? = nil
     ) {}
 
     public func start() -> Bool {

--- a/scripts/check_static_safety.sh
+++ b/scripts/check_static_safety.sh
@@ -40,4 +40,9 @@ scan_forbidden '\\bsudo\\b|LaunchDaemon|/Library/LaunchDaemons|/Library/Privileg
 # 4) Chrome / Logi Options+ config touching
 scan_forbidden 'defaults[[:space:]]+write[[:space:]].*(com\\.google\\.Chrome|Logi)|PlistBuddy.*(Chrome|Logi)|/Google/Chrome/.*/(Preferences|Local State)|Logi Options\\+/.+\\.(json|plist)|sqlite3.*(Chrome|Logi)' 'Chrome/Logi config modification or access'
 
+# 5) hot path logging / disk IO regressions
+if rg --line-number -- 'logger|appendLog|FileHandle|FileManager|print\\(|fputs\\(' Sources/ChromeWheelRouterMac/CGEventTapService.swift 2>/dev/null; then
+  fail "event tap service must not log or perform file/stdout IO from the scroll callback hot path"
+fi
+
 echo "static safety checks: OK"


### PR DESCRIPTION
## Summary

- Add explicit performance guardrails to `AGENTS.md` and safety invariants for event tap hot paths and long-running polling.
- Remove per-scroll-event logging from `CGEventTapService` so the callback no longer routes through app disk IO.
- Make menu-bar runtime reconciliation idempotent so status polling does not recreate the event tap every second.
- Cache the frontmost bundle ID from workspace activation notifications and pass that cached state into the event tap service.
- Document the observed pointer-latency failure mode in troubleshooting and project memory.

## Root Cause

The menu-bar app polled status every second and restarted the global event tap whenever the app was enabled. Separately, every scroll event was logged from the event tap callback, and the app logger synchronously opened, sought, wrote, and closed the runtime log. Together these could disturb global input handling and create visible pointer latency during long-running use.

## Validation

- `./scripts/check_static_safety.sh` passed.
- `./scripts/check_all.sh` passed agent state, user-flow, static safety, and core routing checks, then stopped at the known local `XCTest` availability issue.
- `swift build -c release` passed.

## Manual QA

Physical-device behavior still needs validation on a real Mac with Chrome, MX Master/Logi Options+, macOS privacy permissions, and multi-display pointer movement.