### PR TITLE
[codex] Refactor AGENTS into agent map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,175 +1,39 @@
 # AGENTS.md
 
-## Project
+Project: `ChromeWheelRouter`.
 
-Project name: `ChromeWheelRouter`
+This is a narrowly scoped macOS menu bar utility for Chrome-only horizontal scroll routing. It is not a general input automation platform and not a BetterTouchTool clone.
 
-Build a small macOS menu bar utility. It is not a general input automation platform and not a BetterTouchTool clone.
+## Read Order
 
-## MVP behavior
+1. [Scope](ChromeWheelRouter/docs/specs/scope.md)
+2. [Safety constraints](ChromeWheelRouter/docs/specs/safety_constraints.md)
+3. [Hot-path rules](ChromeWheelRouter/docs/specs/hot_path_rules.md)
+4. [Architecture](ChromeWheelRouter/docs/specs/architecture.md)
+5. [Current state](agent_state_harness/current_state.json)
+6. [Engineering nodes](project_control/engineering_nodes.md)
+7. The current issue or task
 
-Only these Chrome-only horizontal scroll behaviors should be changed:
+## Task Modes
 
-- If Google Chrome is the frontmost app
-- and the event is horizontal scroll
-- and the only active modifier is Option
-- then map the scroll direction to Chrome page zoom and swallow the original scroll event.
-- If Google Chrome is the frontmost app
-- and the event is horizontal scroll
-- and the only active modifier is Control
-- then map the scroll direction to Chrome tab switching and swallow the original scroll event.
+- Product or behavior changes: start with scope and safety constraints.
+- Runtime/event-tap changes: read hot-path rules before editing code.
+- Architecture changes: update the focused spec or ADR that owns the decision.
+- Execution-node work: update project memory under `ChromeWheelRouter/docs/development/project_memory/` when the task creates new knowledge.
 
-Everything else must pass through untouched.
-
-## Hard safety rules
-
-These rules are non-negotiable.
-
-1. Do not listen to `keyDown`.
-2. Do not listen to `keyUp`.
-3. Do not record keyboard input.
-4. Do not record typed text.
-5. Do not read Chrome profile data.
-6. Do not read Logi Options+ config or data.
-7. Do not modify Chrome settings.
-8. Do not modify Logi Options+ settings.
-9. Do not modify macOS keyboard shortcuts.
-10. Do not use network APIs.
-11. Do not add telemetry.
-12. Do not require root.
-13. Do not use `sudo` in install scripts.
-14. Do not install kernel extensions.
-15. Do not install system extensions.
-16. Do not install LaunchDaemons.
-17. Do not install privileged helpers.
-18. Do not write to `/System`.
-19. Do not write to `/Library/LaunchDaemons`.
-20. Do not write to `/Library/PrivilegedHelperTools`.
-21. The event tap mask must only include `scrollWheel`.
-22. Unmatched events must return the original event.
-23. Only Chrome + Option-only + horizontal scroll or Chrome + Control-only + horizontal scroll may be swallowed.
-24. Event tap callbacks must not perform disk IO.
-25. Event tap callbacks must not perform network IO.
-26. Event tap callbacks must not call shell commands.
-27. Event tap callbacks must not sleep.
-28. Event tap callbacks must not take blocking locks.
-29. If permissions are missing, fail closed: do not create the event tap.
-30. If runtime state is uncertain, fail open: pass events through.
-31. Event tap callbacks must stay allocation-light and must not perform per-event logging.
-32. Long-running runtime polling must not recreate event taps unless the desired running state or mode changed.
-33. Frontmost-app state should be cached outside the event tap callback when practical; do not add repeated workspace/process lookups to the hot path without a documented reason.
-
-## Target implementation shape
-
-The first real product should be a macOS menu bar app:
-
-- Enable / Disable
-- Dry Run
-- Permission status
-- Open Accessibility settings
-- Open Input Monitoring settings
-- Start at Login toggle
-- Open Logs
-- Quit
-
-The app should eventually ship as a `.dmg` first. A `.pkg` installer is optional.
-
-## Required source boundaries
-
-Core routing must be pure Swift and unit-testable.
-
-Suggested modules:
-
-```text
-Sources/ChromeWheelRouterCore
-Sources/ChromeWheelRouterMac
-Sources/ChromeWheelRouterApp
-```
-
-Core logic must not import AppKit or CoreGraphics unless absolutely necessary. The macOS adapter should translate `CGEvent` into the pure core model.
-
-## Required tests
-
-At minimum, tests must cover:
-
-- non-Chrome + Option + horizontal scroll => pass-through
-- Chrome + vertical scroll => pass-through
-- Chrome + horizontal scroll + no modifier => pass-through
-- Chrome + horizontal scroll + Command => pass-through
-- Chrome + horizontal scroll + Shift => pass-through
-- Chrome + horizontal scroll + Control-only + positive dx => next-tab-and-swallow
-- Chrome + horizontal scroll + Control-only + negative dx => previous-tab-and-swallow
-- Chrome + horizontal scroll + Option+Command => pass-through
-- Chrome + horizontal scroll + Option+Control => pass-through
-- Chrome + horizontal scroll + Option-only + positive dx => zoom-in-and-swallow
-- Chrome + horizontal scroll + Option-only + negative dx => zoom-out-and-swallow
-- disabled router => pass-through
-
-Do not remove these tests. They are the safety contract.
-
-## Commands
-
-Run before opening a PR:
+## Before PR
 
 ```bash
 ./scripts/check_all.sh
 ```
 
-If Swift tooling is available:
+If Swift tooling is available, also run:
 
 ```bash
 swift test
 swift build -c release
 ```
 
-## PR expectations
+## Non-Negotiable Safety Warning
 
-Each PR should be small and reviewable.
-
-Good Codex Cloud tasks:
-
-- implement pure router logic
-- add tests
-- implement macOS event tap adapter
-- add menu bar UI
-- add permission UX
-- add packaging scripts
-- add user docs
-
-Bad Codex Cloud tasks:
-
-- “build a BetterTouchTool clone”
-- “implement all mouse automation”
-- “handle every browser and app”
-- “bypass macOS permissions”
-
-## Manual QA requirement
-
-Final behavior involving MX Master hardware, Logi Options+, Chrome, and macOS privacy permissions must be tested on a real Mac. Codex Cloud cannot validate physical input-device behavior.
-
-
-## Repository organization invariant
-
-No root-level `*_addendum` directories should be introduced. Supplemental materials belong in their canonical directories, for example:
-
-- `agent_state_harness/`
-- `ChromeWheelRouter/docs/specs/`
-- `ChromeWheelRouter/docs/qa/mvp_user_flow_harness/`
-
-## Project memory requirements
-
-When completing any execution node, update project memory if the task creates new knowledge.
-
-Update these files as appropriate:
-
-- `ChromeWheelRouter/docs/development/node_reports/EXEC-XX.md`
-- `ChromeWheelRouter/docs/development/project_memory/node_summaries/EXEC-XX.md`
-- `ChromeWheelRouter/docs/development/project_memory/lessons_learned/*.md`
-- `ChromeWheelRouter/docs/development/project_memory/decisions/ADR-*.md`
-- `ChromeWheelRouter/docs/product/TROUBLESHOOTING.md`
-
-Do not rely on chat history as project memory.
-
-If a bug, toolchain issue, compatibility issue, or safety edge case is discovered, record it in `ChromeWheelRouter/docs/development/project_memory/lessons_learned/`.
-
-If a durable architectural decision is made, record it as an ADR in `ChromeWheelRouter/docs/development/project_memory/decisions/`.
+Never weaken safety constraints. Never expand scope without a Project Definition change. Unmatched events must pass through unchanged, and only Chrome + Option-only + horizontal scroll or Chrome + Control-only + horizontal scroll may be swallowed.

--- a/ChromeWheelRouter/docs/README.md
+++ b/ChromeWheelRouter/docs/README.md
@@ -5,9 +5,17 @@ Feature-specific documentation for ChromeWheelRouter lives here.
 ## Layout
 
 - `product/` - user-facing product docs, release notes, install/uninstall, troubleshooting, and manual QA instructions.
-- `specs/` - feature scope, architecture, safety invariants, product decisions, and technical design.
+- `specs/` - feature scope, architecture, hot-path rules, safety invariants, product decisions, and technical design.
 - `qa/` - user-flow scenarios and manual QA harness material.
 - `acceptance` - owner acceptance runbooks, reports, and local acceptance context capture.
 - `development/` - execution prompts, node reports, project memory, lessons learned, and ADRs tied to ChromeWheelRouter feature work.
 
 Project-level policy, repository control, automation, templates, and owner-control material remain at the repository root.
+
+## Repository Organization Invariant
+
+No root-level `*_addendum` directories should be introduced. Supplemental materials belong in their canonical directories, for example:
+
+- `agent_state_harness/`
+- `ChromeWheelRouter/docs/specs/`
+- `ChromeWheelRouter/docs/qa/mvp_user_flow_harness/`

--- a/ChromeWheelRouter/docs/development/project_memory/README.md
+++ b/ChromeWheelRouter/docs/development/project_memory/README.md
@@ -15,4 +15,12 @@ Use project memory to capture decisions, lessons, and execution summaries so fut
 
 ## Usage guidance
 
-When task work creates new knowledge, update the relevant files in this tree and any related docs (`ChromeWheelRouter/docs/development/node_reports`, `ChromeWheelRouter/docs/product/TROUBLESHOOTING.md`) as directed by `AGENTS.md`.
+When task work creates new knowledge, update the relevant files in this tree and any related docs:
+
+- `ChromeWheelRouter/docs/development/node_reports/EXEC-XX.md`
+- `ChromeWheelRouter/docs/development/project_memory/node_summaries/EXEC-XX.md`
+- `ChromeWheelRouter/docs/development/project_memory/lessons_learned/*.md`
+- `ChromeWheelRouter/docs/development/project_memory/decisions/ADR-*.md`
+- `ChromeWheelRouter/docs/product/TROUBLESHOOTING.md`
+
+If a bug, toolchain issue, compatibility issue, or safety edge case is discovered, record it in `lessons_learned/`. If a durable architectural decision is made, record it as an ADR in `decisions/`.

--- a/ChromeWheelRouter/docs/development/project_memory/decisions/ADR-005-agents-map-progressive-disclosure.md
+++ b/ChromeWheelRouter/docs/development/project_memory/decisions/ADR-005-agents-map-progressive-disclosure.md
@@ -1,0 +1,28 @@
+# ADR-005: AGENTS.md Uses Progressive Disclosure
+
+Date: 2026-04-30
+
+## Status
+
+Accepted
+
+## Context
+
+`AGENTS.md` had become a large mixed manual containing scope, safety rules, architecture, tests, PR expectations, manual QA, repository organization, and project memory guidance. That made it expensive for agents to read and increased the chance of duplicated or stale source-of-truth language.
+
+## Decision
+
+Keep `AGENTS.md` as a concise navigation map. Detailed rules live in focused documents:
+
+- scope in `ChromeWheelRouter/docs/specs/scope.md`
+- safety in `ChromeWheelRouter/docs/specs/safety_constraints.md`
+- event-tap callback rules in `ChromeWheelRouter/docs/specs/hot_path_rules.md`
+- source boundaries in `ChromeWheelRouter/docs/specs/architecture.md`
+- test contract in `ChromeWheelRouter/docs/specs/acceptance_criteria.md`
+- project memory guidance in `ChromeWheelRouter/docs/development/project_memory/README.md`
+
+## Consequences
+
+- Future agents should start from `AGENTS.md` and follow the read order for task-specific detail.
+- Scope changes must update the canonical scope document instead of adding parallel language elsewhere.
+- Compatibility pointer files may exist, but they should not contain new policy text.

--- a/ChromeWheelRouter/docs/specs/acceptance_criteria.md
+++ b/ChromeWheelRouter/docs/specs/acceptance_criteria.md
@@ -12,6 +12,23 @@
 - Vertical scroll => pass through.
 - Disabled mode => all pass through.
 
+## Required Automated Tests
+
+These tests are the safety contract. Do not remove them.
+
+- non-Chrome + Option + horizontal scroll => pass-through
+- Chrome + vertical scroll => pass-through
+- Chrome + horizontal scroll + no modifier => pass-through
+- Chrome + horizontal scroll + Command => pass-through
+- Chrome + horizontal scroll + Shift => pass-through
+- Chrome + horizontal scroll + Control-only + positive dx => next-tab-and-swallow
+- Chrome + horizontal scroll + Control-only + negative dx => previous-tab-and-swallow
+- Chrome + horizontal scroll + Option+Command => pass-through
+- Chrome + horizontal scroll + Option+Control => pass-through
+- Chrome + horizontal scroll + Option-only + positive dx => zoom-in-and-swallow
+- Chrome + horizontal scroll + Option-only + negative dx => zoom-out-and-swallow
+- disabled router => pass-through
+
 ## Installation
 
 Final product should provide:

--- a/ChromeWheelRouter/docs/specs/architecture.md
+++ b/ChromeWheelRouter/docs/specs/architecture.md
@@ -29,6 +29,18 @@ ChromeWheelRouter.app
     └── uninstall script / guide
 ```
 
+## Source Boundaries
+
+Core routing must be pure Swift and unit-testable.
+
+```text
+Sources/ChromeWheelRouterCore
+Sources/ChromeWheelRouterMac
+Sources/ChromeWheelRouterApp
+```
+
+Core logic must not import AppKit or CoreGraphics unless absolutely necessary. The macOS adapter translates `CGEvent` into the pure core model before calling routing logic.
+
 ## Current scaffold
 
 The current repo includes only the safe core layer and harnesses. The actual `CGEventTap` adapter is intentionally not implemented in the scaffold.

--- a/ChromeWheelRouter/docs/specs/hot_path_rules.md
+++ b/ChromeWheelRouter/docs/specs/hot_path_rules.md
@@ -1,0 +1,52 @@
+# Hot-Path Rules
+
+The scroll event tap callback is the runtime hot path. Keep it small, deterministic, and fail-open.
+
+## Event Tap Scope
+
+- The event tap mask must only include `scrollWheel`.
+- Do not listen to `keyDown`.
+- Do not listen to `keyUp`.
+- Do not listen to mouse clicks for the MVP.
+
+## Callback Must Not
+
+The event tap callback must not perform:
+
+- disk IO
+- network IO
+- shell commands
+- sleep
+- blocking locks
+- package installation
+- config mutation
+- user prompts
+- per-event logging
+- repeated workspace or process lookups when equivalent state can be cached outside the callback
+
+## Callback May
+
+The event tap callback may:
+
+- inspect event type
+- inspect horizontal and vertical scroll deltas
+- inspect modifier flags
+- read cached enabled/config state
+- read cached frontmost-app state
+- call pure routing logic
+- post the required Chrome shortcut for matched actions
+- return the original event or swallow the event
+
+## Pass-Through And Swallow Rules
+
+- Unmatched events must return the original event.
+- Only Chrome + Option-only + horizontal scroll may map to page zoom and be swallowed.
+- Only Chrome + Control-only + horizontal scroll may map to tab switching and be swallowed.
+- If runtime state is uncertain, pass events through.
+- If permissions are missing, fail closed by not creating the event tap.
+
+## Long-Running Runtime Rules
+
+- Long-running runtime polling must not recreate event taps unless the desired running state or mode changed.
+- Permission and status checks must stay outside the scroll event callback.
+- Diagnostics for scroll events must be sampled, aggregated, or moved off the event tap hot path.

--- a/ChromeWheelRouter/docs/specs/product_scope.md
+++ b/ChromeWheelRouter/docs/specs/product_scope.md
@@ -1,30 +1,5 @@
 # Product Scope
 
-## In scope
+The canonical scope document is [Scope](scope.md).
 
-1. Pure Swift routing core.
-2. macOS event tap adapter in a later PR.
-3. Chrome-only zoom mapping.
-4. Menu bar control surface.
-5. User-level installation.
-6. Clean uninstall instructions.
-7. Safety-focused documentation.
-8. GitHub Actions CI.
-9. DMG packaging.
-
-## Out of scope
-
-1. Wuying / cloud desktop support.
-2. System-wide mouse remapping.
-3. Keyboard event monitoring.
-4. Reading user content.
-5. Reading Chrome profile files.
-6. Reading or writing Logi Options+ configuration.
-7. Any network feature.
-8. Any telemetry.
-9. Any root installation.
-10. Any kernel extension or driver.
-
-## Feature gate principle
-
-If a requested feature requires broader event interception or new permissions, it must be explicitly recorded as a product decision before implementation.
+Keep this file only as a compatibility pointer for older task references. Do not add new scope language here.

--- a/ChromeWheelRouter/docs/specs/safety_constraints.md
+++ b/ChromeWheelRouter/docs/specs/safety_constraints.md
@@ -4,26 +4,45 @@ This project changes low-level input routing. Scope discipline matters more than
 
 ## Non-negotiable constraints
 
-- Do not listen to keyDown or keyUp.
-- Do not record text input.
-- Do not collect telemetry.
-- Do not use network APIs.
-- Do not read Chrome profile data.
-- Do not read Logi Options+ files.
-- Do not require root.
-- Do not use sudo.
-- Do not install a LaunchDaemon.
-- Do not install privileged helper tools.
-- Do not install drivers.
-- Do not install kernel extensions.
-- Do not write to system-level directories.
-- Do not modify macOS keyboard shortcuts.
-- Do not modify Chrome settings.
-- Do not modify Logi Options+ settings.
+1. Do not listen to `keyDown`.
+2. Do not listen to `keyUp`.
+3. Do not record keyboard input.
+4. Do not record typed text.
+5. Do not read Chrome profile data.
+6. Do not read Logi Options+ config or data.
+7. Do not modify Chrome settings.
+8. Do not modify Logi Options+ settings.
+9. Do not modify macOS keyboard shortcuts.
+10. Do not use network APIs.
+11. Do not add telemetry.
+12. Do not require root.
+13. Do not use `sudo` in install scripts.
+14. Do not install kernel extensions.
+15. Do not install system extensions.
+16. Do not install LaunchDaemons.
+17. Do not install privileged helpers.
+18. Do not write to `/System`.
+19. Do not write to `/Library/LaunchDaemons`.
+20. Do not write to `/Library/PrivilegedHelperTools`.
+21. The event tap mask must only include `scrollWheel`.
+22. Unmatched events must return the original event.
+23. Only Chrome + Option-only + horizontal scroll or Chrome + Control-only + horizontal scroll may be swallowed.
+24. Event tap callbacks must not perform disk IO.
+25. Event tap callbacks must not perform network IO.
+26. Event tap callbacks must not call shell commands.
+27. Event tap callbacks must not sleep.
+28. Event tap callbacks must not take blocking locks.
+29. If permissions are missing, fail closed: do not create the event tap.
+30. If runtime state is uncertain, fail open: pass events through.
+31. Event tap callbacks must stay allocation-light and must not perform per-event logging.
+32. Long-running runtime polling must not recreate event taps unless the desired running state or mode changed.
+33. Frontmost-app state should be cached outside the event tap callback when practical; do not add repeated workspace/process lookups to the hot path without a documented reason.
 
 ## Runtime constraints
 
 The event tap callback must remain extremely small.
+
+Detailed callback rules live in [Hot-Path Rules](hot_path_rules.md).
 
 Forbidden inside callback:
 

--- a/ChromeWheelRouter/docs/specs/scope.md
+++ b/ChromeWheelRouter/docs/specs/scope.md
@@ -1,0 +1,58 @@
+# Scope
+
+ChromeWheelRouter is a small macOS menu bar utility for Chrome-only horizontal scroll routing. It is not a general input automation platform and not a BetterTouchTool clone.
+
+## MVP Behavior
+
+Only these Chrome-only horizontal scroll behaviors may be changed:
+
+- If Google Chrome is the frontmost app, the event is horizontal scroll, and the only active modifier is Option, map scroll direction to Chrome page zoom and swallow the original scroll event.
+- If Google Chrome is the frontmost app, the event is horizontal scroll, and the only active modifier is Control, map scroll direction to Chrome tab switching and swallow the original scroll event.
+
+Everything else must pass through untouched.
+
+## In Scope
+
+1. Pure Swift routing core.
+2. macOS event tap adapter.
+3. Chrome-only zoom mapping.
+4. Chrome-only tab switching mapping.
+5. Menu bar control surface.
+6. User-level installation.
+7. Clean uninstall instructions.
+8. Safety-focused documentation.
+9. GitHub Actions CI.
+10. DMG packaging.
+
+## Out of Scope
+
+1. Wuying / cloud desktop support.
+2. System-wide mouse remapping.
+3. General browser automation.
+4. Keyboard event monitoring.
+5. Reading user content.
+6. Reading Chrome profile files.
+7. Reading or writing Logi Options+ configuration.
+8. Any network feature.
+9. Any telemetry.
+10. Any root installation.
+11. Any kernel extension or driver.
+
+## Target Product Shape
+
+The first real product is a macOS menu bar app with:
+
+- Enable / Disable
+- Dry Run
+- Permission status
+- Open Accessibility settings
+- Open Input Monitoring settings
+- Start at Login toggle
+- Open Logs
+- Quit
+
+The app should ship as a `.dmg` first. A `.pkg` installer is optional.
+
+## Feature Gate Principle
+
+If a requested feature requires broader event interception, new permissions, or behavior outside Chrome-only horizontal scroll routing, it must be explicitly recorded as a product decision before implementation.


### PR DESCRIPTION
## Summary

- Refactor `AGENTS.md` into a concise agent-readable navigation map.
- Add canonical focused docs for scope and hot-path rules.
- Move detailed safety, architecture, test-contract, repository organization, and project-memory guidance into focused documents.
- Record the progressive-disclosure harness decision in ADR-005.

Closes #28.

## Validation

- `git diff --check`
- `./scripts/check_static_safety.sh`
- `./scripts/check_all.sh` passed agent state, MVP user-flow harness, static safety, and core routing checks before local SwiftPM failed on the existing `XCTest` toolchain issue documented in project memory.

@codex