### PR TITLE
Add quality gate manifest

### DIFF
--- a/.github/workflows/autopilot-gate.yml
+++ b/.github/workflows/autopilot-gate.yml
@@ -15,14 +15,8 @@ jobs:
           uname -a
           swift --version || true
           python3 --version
-      - name: Run project checks
-        run: |
-          if [ -x ./scripts/check_all.sh ]; then
-            CWR_RUN_XCTEST=1 ./scripts/check_all.sh
-          else
-            echo "No check_all.sh found"
-            exit 1
-          fi
+      - name: Run integration gate
+        run: python3 scripts/run_gate.py integration
       - name: Ensure node report exists on PRs
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Show Swift version
         run: swift --version
-      - name: Run all checks
-        run: CWR_RUN_XCTEST=1 ./scripts/check_all.sh
+      - name: Run integration gate
+        run: python3 scripts/run_gate.py integration

--- a/ChromeWheelRouter/docs/development/node_reports/HARNESS-02.md
+++ b/ChromeWheelRouter/docs/development/node_reports/HARNESS-02.md
@@ -13,6 +13,7 @@ Added a single machine-readable quality gate manifest and a repository-local run
 - Updated `scripts/check_all.sh` to delegate its reusable check set to the fast gate while preserving conditional `swift test` behavior.
 - Updated CI workflows to run the integration gate.
 - Documented when to run each gate in `README.md`.
+- Addressed PR review feedback by limiting fast-gate consistency preflight to fast commands and making `python3 scripts/run_gate.py manual` list required human checks.
 
 ## Safety Confirmation
 
@@ -27,6 +28,7 @@ Run in this task:
 - `env PYTHONPYCACHEPREFIX=/private/tmp/cwr_pycache python3 -m py_compile scripts/run_gate.py scripts/check_harness_consistency.py`
 - `./scripts/check_swift_boundaries.sh`
 - `python3 -S ./scripts/check_harness_consistency.py`
+- `python3 scripts/run_gate.py manual`
 - `python3 scripts/run_gate.py fast`
 - `python3 scripts/run_gate.py integration`
 - `python3 scripts/run_gate.py missing_gate`
@@ -37,6 +39,7 @@ Result:
 - Python compile check: PASS with cache redirected to `/private/tmp/cwr_pycache`.
 - `./scripts/check_swift_boundaries.sh`: PASS.
 - `python3 -S ./scripts/check_harness_consistency.py`: PASS.
+- `python3 scripts/run_gate.py manual`: PASS; prints required human validation items.
 - `python3 scripts/run_gate.py fast`: PASS when rerun outside the sandbox.
 - `python3 scripts/run_gate.py integration`: updated fast gate PASS outside the sandbox, then BLOCKED at `swift test` for the same local `XCTest` toolchain issue.
 - `python3 scripts/run_gate.py missing_gate`: PASS for failure behavior; exits 2 and lists available gates.

--- a/ChromeWheelRouter/docs/development/node_reports/HARNESS-02.md
+++ b/ChromeWheelRouter/docs/development/node_reports/HARNESS-02.md
@@ -1,0 +1,44 @@
+# HARNESS-02 Node Report - Machine-Readable Quality Gates
+
+Date: 2026-04-30
+
+## Scope
+
+Added a single machine-readable quality gate manifest and a repository-local runner for fast, integration, release, and manual gates.
+
+## Changes
+
+- Added `harness/quality_gates.yml`.
+- Added `scripts/run_gate.py`.
+- Updated `scripts/check_all.sh` to delegate its reusable check set to the fast gate while preserving conditional `swift test` behavior.
+- Updated CI workflows to run the integration gate.
+- Documented when to run each gate in `README.md`.
+
+## Safety Confirmation
+
+- No app runtime code changed.
+- No event tap behavior changed.
+- No network APIs, telemetry, privileged helpers, launch daemons, system extensions, or root requirements were added.
+
+## Validation
+
+Run in this task:
+
+- `env PYTHONPYCACHEPREFIX=/private/tmp/cwr_pycache python3 -m py_compile scripts/run_gate.py scripts/check_harness_consistency.py`
+- `./scripts/check_swift_boundaries.sh`
+- `python3 -S ./scripts/check_harness_consistency.py`
+- `python3 scripts/run_gate.py fast`
+- `python3 scripts/run_gate.py integration`
+- `python3 scripts/run_gate.py missing_gate`
+- `./scripts/check_all.sh`
+
+Result:
+
+- Python compile check: PASS with cache redirected to `/private/tmp/cwr_pycache`.
+- `./scripts/check_swift_boundaries.sh`: PASS.
+- `python3 -S ./scripts/check_harness_consistency.py`: PASS.
+- `python3 scripts/run_gate.py fast`: PASS when rerun outside the sandbox.
+- `python3 scripts/run_gate.py integration`: updated fast gate PASS outside the sandbox, then BLOCKED at `swift test` for the same local `XCTest` toolchain issue.
+- `python3 scripts/run_gate.py missing_gate`: PASS for failure behavior; exits 2 and lists available gates.
+- First sandboxed gate/check runs hit Swift module cache permission denial under `/Users/vinvancan/.cache/clang/ModuleCache`.
+- `./scripts/check_all.sh`: updated fast gate PASS outside the sandbox, then BLOCKED at `swift test` because this machine's selected Command Line Tools environment cannot import `XCTest` (`no such module 'XCTest'`).

--- a/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-02.md
+++ b/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-02.md
@@ -1,0 +1,5 @@
+# HARNESS-02 - Machine-Readable Quality Gates
+
+Date: 2026-04-30
+
+Added `harness/quality_gates.yml` as the single quality gate manifest and `scripts/run_gate.py` as its runner. `check_all.sh` now delegates shared harness/static/core checks to the fast gate, while CI workflows run the integration gate before merge.

--- a/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-02.md
+++ b/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-02.md
@@ -2,4 +2,4 @@
 
 Date: 2026-04-30
 
-Added `harness/quality_gates.yml` as the single quality gate manifest and `scripts/run_gate.py` as its runner. `check_all.sh` now delegates shared harness/static/core checks to the fast gate, while CI workflows run the integration gate before merge.
+Added `harness/quality_gates.yml` as the single quality gate manifest and `scripts/run_gate.py` as its runner. `check_all.sh` now delegates shared harness/static/core checks to the fast gate, while CI workflows run the integration gate before merge. Follow-up review fixes made the manual gate runnable as a listing command and kept fast-gate consistency checks from preflighting integration/release-only tools.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,16 @@ See [`ChromeWheelRouter/docs/README.md`](ChromeWheelRouter/docs/README.md) for t
 ## Local checks
 
 ```bash
+python3 scripts/run_gate.py fast
 ./scripts/check_all.sh
 ```
+
+Quality gates are defined in [`harness/quality_gates.yml`](harness/quality_gates.yml):
+
+- `fast`: run before every agent handoff and local PR draft.
+- `integration`: run in CI and before merge.
+- `release`: run before RC/release artifact creation.
+- `manual`: human validation required on a real Mac with Chrome, MX Master hardware, Logi Options+, and macOS privacy permissions.
 
 ## Current status
 

--- a/harness/quality_gates.yml
+++ b/harness/quality_gates.yml
@@ -1,0 +1,37 @@
+version: 1
+
+gates:
+  fast:
+    purpose: "Run before every agent handoff and local PR draft."
+    commands:
+      - "python3 -S agent_state_harness/scripts/check_state.py"
+      - "python3 -S ChromeWheelRouter/docs/qa/mvp_user_flow_harness/scripts/check_user_flows.py"
+      - "./scripts/check_static_safety.sh"
+      - "./scripts/run_core_routing_tests.sh"
+      - "./scripts/check_swift_boundaries.sh"
+      - "python3 -S ./scripts/check_harness_consistency.py"
+
+  integration:
+    purpose: "Run in CI and before merge."
+    commands:
+      - "CWR_RUN_XCTEST=1 ./scripts/check_all.sh"
+      - "swift build -c release"
+
+  release:
+    purpose: "Run before RC/release artifact creation."
+    commands:
+      - "./scripts/package_rc.sh"
+    required_artifacts:
+      - "dist/SHA256SUMS"
+      - "dist/build_manifest.json"
+      - "dist/test_report.txt"
+      - "dist/static_safety_report.txt"
+
+manual:
+  required:
+    - "Chrome bare horizontal scroll remains pass-through"
+    - "Chrome Option horizontal scroll performs zoom"
+    - "Chrome Control horizontal scroll switches tabs"
+    - "Disable restores pass-through"
+    - "Quit restores pass-through"
+    - "Uninstall removes files and documents permission revocation"

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -4,15 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-python3 -S agent_state_harness/scripts/check_state.py
-python3 -S ChromeWheelRouter/docs/qa/mvp_user_flow_harness/scripts/check_user_flows.py
-./scripts/check_static_safety.sh
-
-if [ "$(uname -s)" = "Darwin" ]; then
-  ./scripts/run_core_routing_tests.sh
-else
-  echo "core routing tests skipped: non-Darwin environment"
-fi
+python3 scripts/run_gate.py fast
 
 run_xtest="${CWR_RUN_XCTEST:-0}"
 has_swift_package=0

--- a/scripts/check_harness_consistency.py
+++ b/scripts/check_harness_consistency.py
@@ -38,8 +38,8 @@ def main() -> int:
             commands = gate.get("commands", [])
             if not commands:
                 raise AssertionError(f"harness/quality_gates.yml gate has no commands: {gate_name}")
-            for command in commands:
-                preflight_command(command)
+        for command in manifest["gates"]["fast"].get("commands", []):
+            preflight_command(command)
 
         require_contains("scripts/check_all.sh", "python3 scripts/run_gate.py fast")
         require_contains(".github/workflows/ci.yml", "python3 scripts/run_gate.py integration")

--- a/scripts/check_harness_consistency.py
+++ b/scripts/check_harness_consistency.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Check that quality gate wiring stays consistent across repo entry points."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from run_gate import MANIFEST, load_manifest, preflight_command
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    full_path = ROOT / path
+    if not full_path.exists():
+        raise AssertionError(f"missing required file: {path}")
+    return full_path.read_text(encoding="utf-8")
+
+
+def require_contains(path: str, needle: str) -> None:
+    content = read(path)
+    if needle not in content:
+        raise AssertionError(f"{path} must contain {needle!r}")
+
+
+def main() -> int:
+    try:
+        manifest_text = read("harness/quality_gates.yml")
+        manifest = load_manifest(MANIFEST)
+        for gate in ("fast", "integration", "release"):
+            if gate not in manifest["gates"]:
+                raise AssertionError(f"harness/quality_gates.yml missing gate: {gate}")
+        if "manual:" not in manifest_text or not manifest["manual"].get("required"):
+            raise AssertionError("harness/quality_gates.yml missing manual required gate entries")
+        for gate_name, gate in manifest["gates"].items():
+            commands = gate.get("commands", [])
+            if not commands:
+                raise AssertionError(f"harness/quality_gates.yml gate has no commands: {gate_name}")
+            for command in commands:
+                preflight_command(command)
+
+        require_contains("scripts/check_all.sh", "python3 scripts/run_gate.py fast")
+        require_contains(".github/workflows/ci.yml", "python3 scripts/run_gate.py integration")
+        require_contains(".github/workflows/autopilot-gate.yml", "python3 scripts/run_gate.py integration")
+    except AssertionError as exc:
+        print(f"harness consistency check failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("harness consistency checks: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_swift_boundaries.sh
+++ b/scripts/check_swift_boundaries.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+core_dir="Sources/ChromeWheelRouterCore"
+
+if [ ! -d "$core_dir" ]; then
+  echo "missing core source directory: $core_dir" >&2
+  exit 1
+fi
+
+if rg -n '^import (AppKit|CoreGraphics)$' "$core_dir"; then
+  echo "swift boundary violation: core must not import AppKit or CoreGraphics" >&2
+  exit 1
+fi
+
+echo "swift boundary checks: OK"

--- a/scripts/run_gate.py
+++ b/scripts/run_gate.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Run a quality gate from harness/quality_gates.yml."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "harness" / "quality_gates.yml"
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def load_manifest(path: Path) -> dict:
+    if not path.exists():
+        raise ValueError(f"quality gate manifest not found: {path}")
+
+    manifest: dict = {"gates": {}, "manual": {"required": []}}
+    current_section: str | None = None
+    current_gate: str | None = None
+    current_key: str | None = None
+
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent % 2 != 0:
+            raise ValueError(f"{path}:{line_number}: indentation must use two-space levels")
+
+        if indent == 0:
+            if stripped == "gates:":
+                current_section = "gates"
+                current_gate = None
+                current_key = None
+            elif stripped == "manual:":
+                current_section = "manual"
+                current_gate = None
+                current_key = None
+            elif stripped.startswith("version:"):
+                manifest["version"] = int(stripped.split(":", 1)[1].strip())
+            else:
+                raise ValueError(f"{path}:{line_number}: unsupported top-level entry: {stripped}")
+            continue
+
+        if current_section == "gates":
+            if indent == 2 and stripped.endswith(":"):
+                current_gate = stripped[:-1]
+                manifest["gates"][current_gate] = {}
+                current_key = None
+            elif indent == 4 and current_gate:
+                key, separator, value = stripped.partition(":")
+                if not separator:
+                    raise ValueError(f"{path}:{line_number}: expected gate key")
+                current_key = key
+                if value.strip():
+                    manifest["gates"][current_gate][key] = _unquote(value.strip())
+                else:
+                    manifest["gates"][current_gate][key] = []
+            elif indent == 6 and current_gate and current_key and stripped.startswith("- "):
+                value = _unquote(stripped[2:])
+                target = manifest["gates"][current_gate].setdefault(current_key, [])
+                if not isinstance(target, list):
+                    raise ValueError(f"{path}:{line_number}: cannot append list item to scalar key")
+                target.append(value)
+            else:
+                raise ValueError(f"{path}:{line_number}: unsupported gate manifest entry")
+            continue
+
+        if current_section == "manual":
+            if indent == 2 and stripped == "required:":
+                current_key = "required"
+            elif indent == 4 and current_key == "required" and stripped.startswith("- "):
+                manifest["manual"]["required"].append(_unquote(stripped[2:]))
+            else:
+                raise ValueError(f"{path}:{line_number}: unsupported manual gate entry")
+            continue
+
+        raise ValueError(f"{path}:{line_number}: entry is outside a supported section")
+
+    if manifest.get("version") != 1:
+        raise ValueError(f"unsupported quality gate manifest version: {manifest.get('version')!r}")
+    return manifest
+
+
+def command_executable(command: str) -> str:
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ValueError(f"invalid command syntax {command!r}: {exc}") from exc
+
+    while tokens and "=" in tokens[0] and not tokens[0].startswith("="):
+        name, _, _ = tokens[0].partition("=")
+        if not name or any(ch in name for ch in "/."):
+            break
+        tokens.pop(0)
+
+    if not tokens:
+        raise ValueError(f"missing executable in command: {command!r}")
+    return tokens[0]
+
+
+def preflight_command(command: str) -> None:
+    executable = command_executable(command)
+    if executable.startswith("./") or executable.startswith("../") or "/" in executable:
+        path = (ROOT / executable).resolve() if not executable.startswith("/") else Path(executable)
+        if not path.exists():
+            raise ValueError(f"missing command executable for {command!r}: {path}")
+        if not os.access(path, os.X_OK):
+            raise ValueError(f"command is not executable for {command!r}: {path}")
+    elif shutil.which(executable) is None:
+        raise ValueError(f"missing command executable for {command!r}: {executable}")
+
+
+def run_gate(name: str, manifest: dict) -> int:
+    gates = manifest["gates"]
+    if name not in gates:
+        available = ", ".join(sorted(gates))
+        print(f"unknown quality gate: {name}", file=sys.stderr)
+        print(f"available gates: {available}", file=sys.stderr)
+        return 2
+
+    gate = gates[name]
+    commands = gate.get("commands", [])
+    if not isinstance(commands, list) or not commands:
+        print(f"quality gate {name!r} has no commands", file=sys.stderr)
+        return 2
+
+    try:
+        for command in commands:
+            preflight_command(command)
+    except ValueError as exc:
+        print(f"quality gate manifest error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"quality gate: {name}")
+    purpose = gate.get("purpose")
+    if purpose:
+        print(f"purpose: {purpose}")
+
+    for command in commands:
+        print(f"+ {command}", flush=True)
+        completed = subprocess.run(command, cwd=ROOT, shell=True)
+        if completed.returncode != 0:
+            print(f"quality gate {name!r} failed on command: {command}", file=sys.stderr)
+            return completed.returncode
+
+    artifacts = gate.get("required_artifacts", [])
+    missing = [artifact for artifact in artifacts if not (ROOT / artifact).exists()]
+    if missing:
+        for artifact in missing:
+            print(f"missing required artifact: {artifact}", file=sys.stderr)
+        return 1
+
+    print(f"quality gate {name}: OK")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a ChromeWheelRouter quality gate.")
+    parser.add_argument("gate", help="Gate name from harness/quality_gates.yml")
+    args = parser.parse_args()
+
+    try:
+        manifest = load_manifest(MANIFEST)
+    except ValueError as exc:
+        print(f"quality gate manifest error: {exc}", file=sys.stderr)
+        return 2
+
+    return run_gate(args.gate, manifest)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_gate.py
+++ b/scripts/run_gate.py
@@ -126,9 +126,12 @@ def preflight_command(command: str) -> None:
 
 
 def run_gate(name: str, manifest: dict) -> int:
+    if name == "manual":
+        return run_manual_gate(manifest)
+
     gates = manifest["gates"]
     if name not in gates:
-        available = ", ".join(sorted(gates))
+        available = ", ".join(sorted([*gates, "manual"]))
         print(f"unknown quality gate: {name}", file=sys.stderr)
         print(f"available gates: {available}", file=sys.stderr)
         return 2
@@ -166,6 +169,20 @@ def run_gate(name: str, manifest: dict) -> int:
         return 1
 
     print(f"quality gate {name}: OK")
+    return 0
+
+
+def run_manual_gate(manifest: dict) -> int:
+    required = manifest.get("manual", {}).get("required", [])
+    if not isinstance(required, list) or not required:
+        print("quality gate manifest error: manual gate has no required checks", file=sys.stderr)
+        return 2
+
+    print("quality gate: manual")
+    print("required human validation:")
+    for item in required:
+        print(f"- {item}")
+    print("quality gate manual: listed")
     return 0
 
 


### PR DESCRIPTION
## Summary

- Added `harness/quality_gates.yml` as the machine-readable source for fast, integration, release, and manual quality gates.
- Added `scripts/run_gate.py` to execute manifest-defined gates from the repository root with clear errors for unknown gates, missing executables, and missing release artifacts.
- Added harness consistency and Swift boundary checks, then wired `check_all.sh`, CI, and the autopilot gate to the manifest-backed gates.
- Documented gate usage and recorded HARNESS-02 project memory.

## Why

Issue #29 asks for one machine-readable definition of quality gates so agents and CI do not infer which checks apply at each stage.

Closes #29.

## Related Context

- Issue: #29 `HARNESS-02 Add machine-readable quality gates manifest`
- Manifest: `harness/quality_gates.yml`
- Runner: `scripts/run_gate.py`
- Compatibility entry point: `scripts/check_all.sh`
- CI wiring: `.github/workflows/ci.yml`, `.github/workflows/autopilot-gate.yml`
- Project memory: `ChromeWheelRouter/docs/development/node_reports/HARNESS-02.md`, `ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-02.md`

## PR Reuse Check

- Existing PR for branch: none found with `gh pr list --head codex/harness-02-quality-gates`
- Action taken: created new draft PR

## Confidence Proof

- Checked `AGENTS.md` scope and safety constraints: this change only affects harness/scripts/docs/workflows and does not alter event tap behavior.
- Checked issue #29 acceptance criteria against the implementation:
  - `python3 scripts/run_gate.py fast` works locally outside the sandbox.
  - `python3 scripts/run_gate.py integration` is wired for CI/macOS runner context and reaches `swift test` locally before the known local XCTest blocker.
  - Invalid gate names fail clearly and list available gates.
  - `check_all.sh` remains the compatibility entry point and delegates shared checks to the fast gate.
- Added `scripts/check_harness_consistency.py` so the manifest wiring is itself validated by the fast gate.
- Added `scripts/check_swift_boundaries.sh` to cover the boundary check named in the issue's proposed fast gate.

## Conflict / Target-Branch Check

- Target branch: `origin/main`
- Merge base: `1ea1e5d3acf797fc898789dbcb1bbe6d54f4f0e2`
- Conflict status: no conflicts detected; branch was created after fast-forwarding from `origin/main`
- Whitespace check: `git diff --check origin/main...HEAD` passed

## Validation

- `env PYTHONPYCACHEPREFIX=/private/tmp/cwr_pycache python3 -m py_compile scripts/run_gate.py scripts/check_harness_consistency.py`: PASS
- `./scripts/check_swift_boundaries.sh`: PASS
- `python3 -S ./scripts/check_harness_consistency.py`: PASS
- `python3 scripts/run_gate.py fast`: PASS outside sandbox
- `python3 scripts/run_gate.py missing_gate`: expected failure, exits 2 and lists available gates
- `python3 scripts/run_gate.py integration`: BLOCKED locally after fast gate passes; `swift test` fails in this local Command Line Tools environment with `no such module 'XCTest'`
- `./scripts/check_all.sh`: BLOCKED locally for the same `XCTest` issue after the fast gate passes
