### PR TITLE
HARNESS-03 Add boundary and hot-path sensors

### DIFF
--- a/ChromeWheelRouter/docs/development/node_reports/HARNESS-03.md
+++ b/ChromeWheelRouter/docs/development/node_reports/HARNESS-03.md
@@ -1,0 +1,20 @@
+# HARNESS-03 - Architecture Boundary and Hot-Path Safety Sensors
+
+## Scope
+
+Issue #30 adds mechanical checks for Swift module boundaries and event-tap hot-path safety.
+
+## Changes
+
+- Tightened `scripts/check_swift_boundaries.sh` to enforce Core purity, App event-tap ownership boundaries, and CLI routing delegation.
+- Added `scripts/check_hot_path_safety.sh` to reject slow or unsafe operations in `CGEventTapService`.
+- Wired the hot-path check into the fast quality gate in `harness/quality_gates.yml`.
+- Removed the default per-event `NSWorkspace.shared.frontmostApplication` lookup from `CGEventTapService`.
+- Updated the CLI to provide cached frontmost-app state through workspace activation notifications.
+- Documented the boundary model in `ChromeWheelRouter/docs/specs/architecture.md`.
+
+## Validation
+
+- `./scripts/check_swift_boundaries.sh`
+- `./scripts/check_hot_path_safety.sh`
+

--- a/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-03.md
+++ b/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-03.md
@@ -1,0 +1,11 @@
+# HARNESS-03 Summary
+
+Added architecture and hot-path safety sensors for issue #30.
+
+Key knowledge:
+
+- `ChromeWheelRouterCore` must remain free of AppKit, CoreGraphics, and ApplicationServices.
+- Raw event tap APIs belong in `ChromeWheelRouterMac`; App and CLI should provide runtime state and delegate routing.
+- `CGEventTapService` must not default to `NSWorkspace.shared.frontmostApplication` because callers that forget to provide cached state would reintroduce a per-event workspace lookup.
+- Tap-disabled diagnostics should be delivered off the callback stack so App logging does not run synchronously inside the event tap callback.
+

--- a/ChromeWheelRouter/docs/specs/architecture.md
+++ b/ChromeWheelRouter/docs/specs/architecture.md
@@ -37,9 +37,14 @@ Core routing must be pure Swift and unit-testable.
 Sources/ChromeWheelRouterCore
 Sources/ChromeWheelRouterMac
 Sources/ChromeWheelRouterApp
+Sources/ChromeWheelRouterCLI
 ```
 
-Core logic must not import AppKit or CoreGraphics unless absolutely necessary. The macOS adapter translates `CGEvent` into the pure core model before calling routing logic.
+Core logic must not import AppKit, CoreGraphics, or ApplicationServices. The macOS adapter translates `CGEvent` into the pure core model before calling routing logic.
+
+`ChromeWheelRouterMac` owns raw event tap APIs, `CGEvent` conversion, and Chrome shortcut injection. `ChromeWheelRouterApp` owns menu bar UI, permissions, logs, and long-running runtime state; it must pass cached state into the Mac adapter instead of creating event taps or parsing `CGEvent` directly. `ChromeWheelRouterCLI` may host a small runtime shell, but it must delegate event handling and route decisions to Core/Mac rather than reimplement routing rules.
+
+The event tap hot path must receive cached frontmost-app state. Direct `NSWorkspace.shared.frontmostApplication` lookups belong outside the callback path, such as startup initialization or workspace activation notifications.
 
 ## Current scaffold
 

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "ChromeWheelRouterCLI",
-            dependencies: ["ChromeWheelRouterCore", "ChromeWheelRouterMac"]
+            dependencies: ["ChromeWheelRouterMac"]
         ),
         .executableTarget(
             name: "ChromeWheelRouterApp",

--- a/Sources/ChromeWheelRouterCLI/main.swift
+++ b/Sources/ChromeWheelRouterCLI/main.swift
@@ -1,12 +1,48 @@
+import AppKit
 import Foundation
-import ChromeWheelRouterCore
 import ChromeWheelRouterMac
 
+final class FrontmostApplicationCache {
+    private var cachedBundleID: String
+    private var observer: NSObjectProtocol?
+
+    init() {
+        cachedBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+        observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard
+                let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                let bundleIdentifier = app.bundleIdentifier
+            else {
+                self?.cachedBundleID = "unknown"
+                return
+            }
+            self?.cachedBundleID = bundleIdentifier
+        }
+    }
+
+    deinit {
+        if let observer {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
+
+    func currentBundleID() -> String {
+        cachedBundleID
+    }
+}
 
 struct CLI {
     static func run(arguments: [String]) throws {
         let mode = try parseMode(arguments: arguments)
-        let service = CGEventTapService(mode: mode)
+        let frontmostApplicationCache = FrontmostApplicationCache()
+        let service = CGEventTapService(
+            mode: mode,
+            frontmostBundleID: { frontmostApplicationCache.currentBundleID() }
+        )
 
         guard service.start() else {
             fputs("Failed to create scrollWheel-only event tap. Check macOS privacy permissions.\n", stderr)

--- a/Sources/ChromeWheelRouterMac/CGEventTapService.swift
+++ b/Sources/ChromeWheelRouterMac/CGEventTapService.swift
@@ -22,9 +22,7 @@ public final class CGEventTapService {
         router: Router = Router(),
         mode: EventTapMode,
         isEnabled: @escaping () -> Bool = { true },
-        frontmostBundleID: @escaping () -> String = {
-            NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
-        },
+        frontmostBundleID: @escaping () -> String = { "unknown" },
         keyboardInjector: KeyboardInjecting = CGKeyboardInjector(),
         onTapDisabled: ((EventTapDisableReason) -> Void)? = nil
     ) {
@@ -91,9 +89,9 @@ public final class CGEventTapService {
             }
 
             if type == .tapDisabledByTimeout {
-                onTapDisabled?(.timeout)
+                notifyTapDisabled(.timeout)
             } else {
-                onTapDisabled?(.userInput)
+                notifyTapDisabled(.userInput)
             }
             return Unmanaged.passUnretained(event)
         }
@@ -129,6 +127,16 @@ public final class CGEventTapService {
         }
 
         return injected ? nil : Unmanaged.passUnretained(event)
+    }
+
+    private func notifyTapDisabled(_ reason: EventTapDisableReason) {
+        guard let onTapDisabled else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            onTapDisabled(reason)
+        }
     }
 }
 #else

--- a/harness/quality_gates.yml
+++ b/harness/quality_gates.yml
@@ -9,6 +9,7 @@ gates:
       - "./scripts/check_static_safety.sh"
       - "./scripts/run_core_routing_tests.sh"
       - "./scripts/check_swift_boundaries.sh"
+      - "./scripts/check_hot_path_safety.sh"
       - "python3 -S ./scripts/check_harness_consistency.py"
 
   integration:

--- a/scripts/check_harness_consistency.py
+++ b/scripts/check_harness_consistency.py
@@ -42,6 +42,8 @@ def main() -> int:
             preflight_command(command)
 
         require_contains("scripts/check_all.sh", "python3 scripts/run_gate.py fast")
+        require_contains("harness/quality_gates.yml", "./scripts/check_swift_boundaries.sh")
+        require_contains("harness/quality_gates.yml", "./scripts/check_hot_path_safety.sh")
         require_contains(".github/workflows/ci.yml", "python3 scripts/run_gate.py integration")
         require_contains(".github/workflows/autopilot-gate.yml", "python3 scripts/run_gate.py integration")
     except AssertionError as exc:

--- a/scripts/check_hot_path_safety.sh
+++ b/scripts/check_hot_path_safety.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+event_tap="Sources/ChromeWheelRouterMac/CGEventTapService.swift"
+
+if [ ! -f "$event_tap" ]; then
+  echo "missing event tap service source: $event_tap" >&2
+  exit 1
+fi
+
+fail_if_found() {
+  local pattern="$1"
+  local description="$2"
+
+  if search_file "$pattern"; then
+    echo "hot-path safety violation: $description" >&2
+    exit 1
+  fi
+}
+
+search_file() {
+  local pattern="$1"
+
+  if command -v rg >/dev/null 2>&1; then
+    rg -n -- "$pattern" "$event_tap"
+  else
+    grep -nE -- "$pattern" "$event_tap"
+  fi
+}
+
+fail_if_found 'NSWorkspace\.shared\.frontmostApplication' "event tap service must receive cached frontmost app state, not query NSWorkspace per event"
+fail_if_found '(^|[^[:alnum:]_])(FileManager|FileHandle|Data\(contentsOf:|write\(to:|OutputStream|InputStream)([^[:alnum:]_]|$)' "event tap service must not perform filesystem IO"
+fail_if_found '(^|[^[:alnum:]_])(URLSession|NSURLSession|NWConnection|NWPathMonitor|CFNetwork)([^[:alnum:]_]|$)|^import[[:space:]]+Network([^[:alnum:]_]|$)' "event tap service must not use network APIs"
+fail_if_found '(^|[^[:alnum:]_])(Task\.sleep|Thread\.sleep|sleep|usleep|nanosleep)([^[:alnum:]_]|$)' "event tap service must not sleep"
+fail_if_found '(^|[^[:alnum:]_])(print|fputs|NSLog|os_log)[[:space:]]*\(|(^|[^[:alnum:]_])(logger|appendLog)([^[:alnum:]_]|$)' "event tap service must not synchronously log or print"
+fail_if_found '(^|[^[:alnum:]_])(DispatchSemaphore|NSLock|NSRecursiveLock|pthread_mutex|objc_sync_enter)([^[:alnum:]_]|$)|\.sync[[:space:]]*(\(|\{)' "event tap service must not take blocking locks"
+fail_if_found '(^|[^[:alnum:]_])(keyDown|keyUp|kCGEventKeyDown|kCGEventKeyUp)([^[:alnum:]_]|$)' "event tap service must not listen for keyboard events"
+
+if command -v rg >/dev/null 2>&1; then
+  mask_found=$(rg -n 'CGEventMask\(1 << CGEventType\.scrollWheel\.rawValue\)' "$event_tap" || true)
+else
+  mask_found=$(grep -nF 'CGEventMask(1 << CGEventType.scrollWheel.rawValue)' "$event_tap" || true)
+fi
+
+if [ -z "$mask_found" ]; then
+  echo "hot-path safety violation: event tap mask must be scrollWheel-only" >&2
+  exit 1
+fi
+
+echo "hot-path safety checks: OK"

--- a/scripts/check_static_safety.sh
+++ b/scripts/check_static_safety.sh
@@ -12,14 +12,21 @@ fail() {
 SCAN_PATHS=(Sources Tests scripts)
 EXCLUDE_GLOBS=(
   "!scripts/check_static_safety.sh"
+  "!scripts/check_hot_path_safety.sh"
 )
 
 scan_forbidden() {
   local pattern="$1"
   local description="$2"
   local out
+  local rg_globs=()
+  local glob
 
-  if out=$(rg --line-number --hidden --glob "${EXCLUDE_GLOBS[0]}" -- "$pattern" "${SCAN_PATHS[@]}" 2>/dev/null); then
+  for glob in "${EXCLUDE_GLOBS[@]}"; do
+    rg_globs+=(--glob "$glob")
+  done
+
+  if out=$(rg --line-number --hidden "${rg_globs[@]}" -- "$pattern" "${SCAN_PATHS[@]}" 2>/dev/null); then
     if [[ -n "$out" ]]; then
       echo "$out" >&2
       fail "forbidden pattern found (${description}): ${pattern}"

--- a/scripts/check_swift_boundaries.sh
+++ b/scripts/check_swift_boundaries.sh
@@ -5,14 +5,37 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 core_dir="Sources/ChromeWheelRouterCore"
+app_dir="Sources/ChromeWheelRouterApp"
+cli_dir="Sources/ChromeWheelRouterCLI"
+
+search_dir() {
+  local pattern="$1"
+  local dir="$2"
+
+  if command -v rg >/dev/null 2>&1; then
+    rg -n -- "$pattern" "$dir"
+  else
+    grep -RInE -- "$pattern" "$dir"
+  fi
+}
 
 if [ ! -d "$core_dir" ]; then
   echo "missing core source directory: $core_dir" >&2
   exit 1
 fi
 
-if rg -n '^import (AppKit|CoreGraphics)$' "$core_dir"; then
-  echo "swift boundary violation: core must not import AppKit or CoreGraphics" >&2
+if search_dir '^import (AppKit|CoreGraphics|ApplicationServices)$' "$core_dir"; then
+  echo "swift boundary violation: core must not import AppKit, CoreGraphics, or ApplicationServices" >&2
+  exit 1
+fi
+
+if [ -d "$app_dir" ] && search_dir '(^|[^[:alnum:]_])(CGEvent|CGEventTap|CGEventMask|CGEventType|CGEventSource|CGKeyCode|CGEventFlags)([^[:alnum:]_]|$)|\.tapCreate([^[:alnum:]_]|$)|kCGEvent' "$app_dir"; then
+  echo "swift boundary violation: app must not bypass ChromeWheelRouterMac with raw CoreGraphics event tap APIs" >&2
+  exit 1
+fi
+
+if [ -d "$cli_dir" ] && search_dir '(^|[^[:alnum:]_])(Router|ScrollEventModel|RouteDecision)([^[:alnum:]_]|$)|\.zoomInAndSwallow|\.zoomOutAndSwallow|\.nextTabAndSwallow|\.previousTabAndSwallow' "$cli_dir"; then
+  echo "swift boundary violation: CLI must delegate routing decisions to ChromeWheelRouterCore/ChromeWheelRouterMac" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Adds a dedicated hot-path safety sensor for `CGEventTapService` and wires it into the fast quality gate.
- Tightens Swift module boundary checks for Core, App, and CLI ownership.
- Refactors the CLI/event-tap construction so frontmost app state is cached outside the callback path.
- Documents the boundary model and records HARNESS-03 project memory.

## Why

Issue #30 asks the harness to mechanically enforce Swift architecture boundaries and prevent slow or unsafe operations in the event-tap hot path. This keeps the Chrome-only horizontal-scroll router inside its safety envelope and prevents regressions like per-event workspace polling or synchronous callback logging.

## Related Context

- Closes #30
- Specs checked: `ChromeWheelRouter/docs/specs/scope.md`, `ChromeWheelRouter/docs/specs/safety_constraints.md`, `ChromeWheelRouter/docs/specs/hot_path_rules.md`, `ChromeWheelRouter/docs/specs/architecture.md`
- Project memory checked: `ChromeWheelRouter/docs/development/project_memory/decisions/ADR-004-event-tap-hot-path-performance-guardrails.md`, `ChromeWheelRouter/docs/development/project_memory/lessons_learned/2026-04-30-event-tap-hot-path-performance.md`
- New memory/report: `ChromeWheelRouter/docs/development/node_reports/HARNESS-03.md`, `ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-03.md`

## PR Reuse Check

- Existing PR for branch: none found with `gh pr list --head codex/issue-30-harness-03`
- Action taken: created new draft PR

## Confidence Proof

- Verified the change keeps Core free of AppKit/CoreGraphics/ApplicationServices.
- Verified App does not directly own raw `CGEvent` or event-tap APIs.
- Removed the event-tap service default that could call `NSWorkspace.shared.frontmostApplication` in the callback path.
- Moved tap-disabled diagnostics onto `DispatchQueue.main.async` so App logging does not run synchronously inside the callback.
- Updated harness consistency checks so future gate wiring drift catches the new sensors.

## Conflict / Target-Branch Check

- Target branch: `origin/main`
- Merge base: `aafc5624e9292077fd7712154b9b6a9fc3f719b5`
- Branch status before commit: `0 ahead / 0 behind` relative to `origin/main`
- Conflict status: no conflicts detected; branch was created from current `origin/main`

## Validation

- `python3 scripts/run_gate.py fast`: passed
- `./scripts/check_swift_boundaries.sh`: passed
- `./scripts/check_hot_path_safety.sh`: passed
- `git diff --check HEAD`: passed
- `swift build -c release`: passed
- `./scripts/check_all.sh`: blocked locally at `swift test` because this Command Line Tools setup cannot load `XCTest` (`no such module 'XCTest'`)

## CI Readiness

- CI status: pending
- Draft status after submission: draft until CI confirms the integration gate on GitHub