### PR TITLE
Add approved router decision fixtures

### DIFF
--- a/ChromeWheelRouter/docs/development/node_reports/HARNESS-04.md
+++ b/ChromeWheelRouter/docs/development/node_reports/HARNESS-04.md
@@ -1,0 +1,33 @@
+# HARNESS-04 Node Report
+
+## Goal
+
+Add an approved-scenarios fixture layer for pure router decisions.
+
+## Changes
+
+- Added `ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json`.
+- Added documentation for reviewing and extending router decision fixtures.
+- Added `scripts/check_router_fixtures.sh` and a Swift fixture runner wired to
+  `Router.decide`.
+- Added the fixture check to the fast quality gate used by `check_all.sh`.
+
+## Safety Scope
+
+The fixtures encode the HARNESS-00 scope decision:
+
+- Chrome + Option-only + horizontal scroll may zoom and swallow.
+- Chrome + Control-only + horizontal scroll may switch tabs and swallow.
+- Non-Chrome, bare horizontal scroll, mixed modifiers, disabled state,
+  vertical-only scroll, and diagonal scroll pass through.
+
+No runtime event tap behavior was changed.
+
+## Validation
+
+Run:
+
+```bash
+./scripts/check_router_fixtures.sh
+./scripts/check_all.sh
+```

--- a/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-04.md
+++ b/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-04.md
@@ -1,0 +1,13 @@
+# HARNESS-04 Summary
+
+Added router decision fixtures as a reviewable behavior matrix under
+`ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json`.
+
+The fixture check compiles the pure Swift router with
+`scripts/check_router_fixtures.swift` and asserts each scenario against
+`Router.decide`. The fast quality gate now runs `./scripts/check_router_fixtures.sh`,
+so `./scripts/check_all.sh` covers the approved scenario matrix before SwiftPM
+tests run.
+
+The fixture layer documents how agents can add scenarios without changing
+generated assertion code, and keeps HARNESS-00 routing scope visible in diffs.

--- a/ChromeWheelRouter/docs/qa/router_decision_fixtures/README.md
+++ b/ChromeWheelRouter/docs/qa/router_decision_fixtures/README.md
@@ -1,0 +1,43 @@
+# Router Decision Fixtures
+
+This directory contains human-readable scenarios for pure router behavior. The
+fixtures are an approved-scenarios layer: reviewers should be able to understand
+behavior changes by reading `scenarios.json`.
+
+Run:
+
+```bash
+./scripts/check_router_fixtures.sh
+```
+
+The check compiles the pure `ChromeWheelRouterCore` sources with the fixture
+runner in `scripts/check_router_fixtures.swift`, decodes `scenarios.json`, and
+asserts each expected decision against `Router.decide`.
+
+## Adding Scenarios
+
+Add a scenario when router behavior changes or a safety invariant needs a
+reviewable example. Keep each `id` stable and unique, and append new IDs rather
+than reusing old ones.
+
+Supported modifier names are:
+
+- `command`
+- `option`
+- `control`
+- `shift`
+
+Supported decision names are:
+
+- `passThrough`
+- `zoomInAndSwallow`
+- `zoomOutAndSwallow`
+- `nextTabAndSwallow`
+- `previousTabAndSwallow`
+
+Fixtures must stay aligned with the HARNESS-00 scope decision:
+
+- Chrome + Option-only + horizontal scroll may zoom and swallow.
+- Chrome + Control-only + horizontal scroll may switch tabs and swallow.
+- Bare horizontal scroll, non-Chrome events, mixed modifiers, disabled state,
+  vertical-only scroll, and diagonal scroll must pass through.

--- a/ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json
+++ b/ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json
@@ -1,0 +1,173 @@
+{
+  "version": 1,
+  "scenarios": [
+    {
+      "id": "ROUTE-001",
+      "name": "Chrome bare horizontal scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": [],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-002",
+      "name": "Non-Chrome Option horizontal scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.apple.finder",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-003",
+      "name": "Chrome vertical-only Option scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 0,
+        "verticalDelta": 1,
+        "modifiers": ["option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-004",
+      "name": "Chrome diagonal Option scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 1,
+        "modifiers": ["option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-005",
+      "name": "Chrome Command horizontal scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["command"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-006",
+      "name": "Chrome Shift horizontal scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["shift"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-007",
+      "name": "Chrome Option Command horizontal scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["option", "command"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-008",
+      "name": "Chrome Control Option horizontal scroll passes through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["control", "option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-009",
+      "name": "Disabled router passes matched Option scroll through",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["option"],
+        "routerEnabled": false
+      },
+      "expectedDecision": "passThrough"
+    },
+    {
+      "id": "ROUTE-010",
+      "name": "Chrome Option positive horizontal scroll zooms in and swallows",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "zoomInAndSwallow"
+    },
+    {
+      "id": "ROUTE-011",
+      "name": "Chrome Option negative horizontal scroll zooms out and swallows",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": -1,
+        "verticalDelta": 0,
+        "modifiers": ["option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "zoomOutAndSwallow"
+    },
+    {
+      "id": "ROUTE-012",
+      "name": "Chrome Control positive horizontal scroll switches to next tab and swallows",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["control"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "nextTabAndSwallow"
+    },
+    {
+      "id": "ROUTE-013",
+      "name": "Chrome Control negative horizontal scroll switches to previous tab and swallows",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome",
+        "horizontalDelta": -1,
+        "verticalDelta": 0,
+        "modifiers": ["control"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "previousTabAndSwallow"
+    },
+    {
+      "id": "ROUTE-014",
+      "name": "Chrome Canary Option horizontal scroll uses Chrome routing",
+      "input": {
+        "frontmostBundleID": "com.google.Chrome.canary",
+        "horizontalDelta": 1,
+        "verticalDelta": 0,
+        "modifiers": ["option"],
+        "routerEnabled": true
+      },
+      "expectedDecision": "zoomInAndSwallow"
+    }
+  ]
+}

--- a/harness/quality_gates.yml
+++ b/harness/quality_gates.yml
@@ -8,6 +8,7 @@ gates:
       - "python3 -S ChromeWheelRouter/docs/qa/mvp_user_flow_harness/scripts/check_user_flows.py"
       - "./scripts/check_static_safety.sh"
       - "./scripts/run_core_routing_tests.sh"
+      - "./scripts/check_router_fixtures.sh"
       - "./scripts/check_swift_boundaries.sh"
       - "./scripts/check_hot_path_safety.sh"
       - "python3 -S ./scripts/check_harness_consistency.py"

--- a/scripts/check_harness_consistency.py
+++ b/scripts/check_harness_consistency.py
@@ -44,6 +44,7 @@ def main() -> int:
         require_contains("scripts/check_all.sh", "python3 scripts/run_gate.py fast")
         require_contains("harness/quality_gates.yml", "./scripts/check_swift_boundaries.sh")
         require_contains("harness/quality_gates.yml", "./scripts/check_hot_path_safety.sh")
+        require_contains("harness/quality_gates.yml", "./scripts/check_router_fixtures.sh")
         require_contains(".github/workflows/ci.yml", "python3 scripts/run_gate.py integration")
         require_contains(".github/workflows/autopilot-gate.yml", "python3 scripts/run_gate.py integration")
     except AssertionError as exc:

--- a/scripts/check_router_fixtures.sh
+++ b/scripts/check_router_fixtures.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v swiftc >/dev/null 2>&1; then
+  echo "router fixture check skipped: swiftc not found"
+  exit 0
+fi
+
+TMPDIR="${TMPDIR:-/tmp}"
+BIN="$TMPDIR/chromewheelrouter-router-fixtures.$$"
+trap 'rm -f "$BIN"' EXIT
+
+swiftc Sources/ChromeWheelRouterCore/*.swift scripts/check_router_fixtures.swift -o "$BIN"
+"$BIN" ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json

--- a/scripts/check_router_fixtures.swift
+++ b/scripts/check_router_fixtures.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+struct FixtureFile: Decodable {
+    let version: Int
+    let scenarios: [Scenario]
+}
+
+struct Scenario: Decodable {
+    let id: String
+    let name: String
+    let input: FixtureInput
+    let expectedDecision: String
+}
+
+struct FixtureInput: Decodable {
+    let frontmostBundleID: String
+    let horizontalDelta: Int64
+    let verticalDelta: Int64
+    let modifiers: [String]
+    let routerEnabled: Bool
+}
+
+@main
+struct RouterFixtureRunner {
+    static func main() {
+        let path = CommandLine.arguments.dropFirst().first ?? "ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json"
+        let url = URL(fileURLWithPath: path)
+
+        do {
+            let data = try Data(contentsOf: url)
+            let fixtures = try JSONDecoder().decode(FixtureFile.self, from: data)
+            try run(fixtures)
+        } catch {
+            fputs("router fixture check failed: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private static func run(_ fixtures: FixtureFile) throws {
+        guard fixtures.version == 1 else {
+            throw FixtureError.unsupportedVersion(fixtures.version)
+        }
+        guard !fixtures.scenarios.isEmpty else {
+            throw FixtureError.emptyScenarios
+        }
+
+        let router = Router()
+        var seenIDs = Set<String>()
+        var failures: [String] = []
+
+        for scenario in fixtures.scenarios {
+            guard seenIDs.insert(scenario.id).inserted else {
+                throw FixtureError.duplicateID(scenario.id)
+            }
+
+            let expected = try decision(named: scenario.expectedDecision)
+            let event = try event(from: scenario.input)
+            let actual = router.decide(event)
+            if actual != expected {
+                failures.append("\(scenario.id) \(scenario.name): expected \(name(for: expected)), got \(name(for: actual))")
+            }
+        }
+
+        if !failures.isEmpty {
+            fputs("router fixture mismatches:\n", stderr)
+            for failure in failures {
+                fputs("- \(failure)\n", stderr)
+            }
+            exit(1)
+        }
+
+        print("router fixtures: OK (\(fixtures.scenarios.count) scenarios)")
+    }
+
+    private static func event(from input: FixtureInput) throws -> ScrollEventModel {
+        ScrollEventModel(
+            frontmostBundleID: input.frontmostBundleID,
+            horizontalDelta: input.horizontalDelta,
+            verticalDelta: input.verticalDelta,
+            modifiers: try modifiers(named: input.modifiers),
+            routerEnabled: input.routerEnabled
+        )
+    }
+
+    private static func modifiers(named names: [String]) throws -> ModifierState {
+        var state: ModifierState = []
+        for name in names {
+            switch name {
+            case "command":
+                state.insert(.command)
+            case "option":
+                state.insert(.option)
+            case "control":
+                state.insert(.control)
+            case "shift":
+                state.insert(.shift)
+            default:
+                throw FixtureError.unknownModifier(name)
+            }
+        }
+        return state
+    }
+
+    private static func decision(named name: String) throws -> RouteDecision {
+        switch name {
+        case "passThrough":
+            return .passThrough
+        case "zoomInAndSwallow":
+            return .zoomInAndSwallow
+        case "zoomOutAndSwallow":
+            return .zoomOutAndSwallow
+        case "nextTabAndSwallow":
+            return .nextTabAndSwallow
+        case "previousTabAndSwallow":
+            return .previousTabAndSwallow
+        default:
+            throw FixtureError.unknownDecision(name)
+        }
+    }
+
+    private static func name(for decision: RouteDecision) -> String {
+        switch decision {
+        case .passThrough:
+            return "passThrough"
+        case .zoomInAndSwallow:
+            return "zoomInAndSwallow"
+        case .zoomOutAndSwallow:
+            return "zoomOutAndSwallow"
+        case .nextTabAndSwallow:
+            return "nextTabAndSwallow"
+        case .previousTabAndSwallow:
+            return "previousTabAndSwallow"
+        }
+    }
+}
+
+enum FixtureError: Error, CustomStringConvertible {
+    case duplicateID(String)
+    case emptyScenarios
+    case unknownDecision(String)
+    case unknownModifier(String)
+    case unsupportedVersion(Int)
+
+    var description: String {
+        switch self {
+        case .duplicateID(let id):
+            return "duplicate scenario id: \(id)"
+        case .emptyScenarios:
+            return "scenarios.json must contain at least one scenario"
+        case .unknownDecision(let name):
+            return "unknown expectedDecision: \(name)"
+        case .unknownModifier(let name):
+            return "unknown modifier: \(name)"
+        case .unsupportedVersion(let version):
+            return "unsupported fixture version: \(version)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a human-readable router decision fixture matrix under `ChromeWheelRouter/docs/qa/router_decision_fixtures/scenarios.json`.
- Add a Swift fixture runner plus `./scripts/check_router_fixtures.sh` so fixtures execute against the real `Router.decide` logic.
- Wire the fixture check into the fast quality gate used by `./scripts/check_all.sh` and record HARNESS-04 node/project-memory context.

## Why

Issue #31 asks for an Approved Scenarios-style fixture layer so router behavior changes are reviewable as data diffs instead of generated assertion code. This keeps the HARNESS-00 routing scope visible for future agents and reviewers.

## Related Context

- Closes #31
- Specs checked: `ChromeWheelRouter/docs/specs/scope.md`, `ChromeWheelRouter/docs/specs/safety_constraints.md`, `ChromeWheelRouter/docs/specs/hot_path_rules.md`, `ChromeWheelRouter/docs/specs/architecture.md`
- Harness state checked: `agent_state_harness/current_state.json`, `project_control/engineering_nodes.md`
- Project memory added: `ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-04.md`

## PR Reuse Check

- Existing PR for branch: none found via `gh pr list --head codex/issue-31-router-fixtures --state all`
- Action taken: created a new draft PR

## Confidence Proof

- Fixtures cover pass-through safety cases for bare horizontal scroll, non-Chrome, vertical-only, diagonal, mixed modifiers, disabled router, Command-only, and Shift-only.
- Fixtures cover the only allowed swallowed cases: Chrome + Option-only horizontal zoom and Chrome + Control-only horizontal tab switching.
- The runner compiles only the pure core router sources plus the fixture executable; no runtime event tap behavior changed.
- Harness consistency now asserts the new fixture check remains wired into `harness/quality_gates.yml`.

## Conflict / Target-Branch Check

- Target branch: `origin/main`
- Merge base: `d4205a7441a6169507e86fdf7d56aca0a3b4a3fd`
- Conflict status: no target-branch drift; branch was created from current `origin/main`

## Validation

- `python3 scripts/run_gate.py fast`: passed
- `./scripts/check_router_fixtures.sh`: passed, `router fixtures: OK (14 scenarios)`
- `git diff --check`: passed
- `swift build -c release`: passed
- `./scripts/check_all.sh`: fast gate passed, then local `swift test` failed because this Command Line Tools environment cannot import XCTest: `no such module 'XCTest'`

## CI Readiness

- CI status: pending after PR creation
- Draft status after CI: draft until GitHub CI proves the full gate, since local XCTest is unavailable