### PR TITLE
Add machine-checkable node report evidence gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - Node ID:
 - Previous node report:
 - Next node:
+- Structured node report evidence block added/updated:
 
 ## What changed
 
@@ -13,7 +14,8 @@
 ## Required evidence
 
 - [ ] `./scripts/check_all.sh` passed, or unavailable checks are explained.
-- [ ] Node report added/updated under `node_reports/`.
+- [ ] Node report added/updated under `ChromeWheelRouter/docs/development/node_reports/`.
+- [ ] Node report includes a fenced `json node-report` block matching `templates/node_report.schema.json`.
 - [ ] Static safety checks passed.
 - [ ] MVP invariant preserved: Chrome bare horizontal scroll => pass-through.
 - [ ] No scope expansion.
@@ -35,3 +37,66 @@
 
 ## Codex notes
 
+Structured node report evidence should include:
+
+```json node-report
+{
+  "node_id": "",
+  "task_source": "",
+  "changed_files": [],
+  "commands_run": [
+    {
+      "command": "python3 scripts/run_gate.py fast",
+      "result": "",
+      "summary": ""
+    },
+    {
+      "command": "./scripts/check_all.sh",
+      "result": "",
+      "summary": ""
+    }
+  ],
+  "safety_invariants_checked": [
+    {
+      "invariant": "no_key_down_key_up_listeners",
+      "checked": true,
+      "summary": ""
+    },
+    {
+      "invariant": "no_network_or_telemetry",
+      "checked": true,
+      "summary": ""
+    },
+    {
+      "invariant": "no_chrome_or_logi_config_access",
+      "checked": true,
+      "summary": ""
+    },
+    {
+      "invariant": "no_root_privileged_helper_or_system_daemon",
+      "checked": true,
+      "summary": ""
+    },
+    {
+      "invariant": "unmatched_events_pass_through",
+      "checked": true,
+      "summary": ""
+    }
+  ],
+  "scope_change": {
+    "changed": false,
+    "summary": ""
+  },
+  "manual_validation_required": {
+    "required": false,
+    "summary": ""
+  },
+  "artifacts": [],
+  "known_risks": [],
+  "next_node": "",
+  "state_updates": {
+    "current_state_json_changed": false,
+    "summary": ""
+  }
+}
+```

--- a/.github/workflows/autopilot-gate.yml
+++ b/.github/workflows/autopilot-gate.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Show environment
         run: |
           uname -a
@@ -17,11 +19,6 @@ jobs:
           python3 --version
       - name: Run integration gate
         run: python3 scripts/run_gate.py integration
-      - name: Ensure node report exists on PRs
+      - name: Validate node report evidence on PRs
         if: github.event_name == 'pull_request'
-        run: |
-          node_report_dir="ChromeWheelRouter/docs/development/node_reports"
-          if ! find "$node_report_dir" -maxdepth 1 -name 'EXEC-*.md' -type f | grep -q .; then
-            echo "Expected a node report under $node_report_dir/EXEC-*.md"
-            exit 1
-          fi
+        run: python3 scripts/check_node_report.py --base "origin/${{ github.base_ref }}" --head HEAD

--- a/ChromeWheelRouter/docs/development/node_reports/HARNESS-05.md
+++ b/ChromeWheelRouter/docs/development/node_reports/HARNESS-05.md
@@ -1,0 +1,98 @@
+# HARNESS-05 Node Report
+
+## Machine-readable evidence
+
+```json node-report
+{
+  "node_id": "HARNESS-05",
+  "task_source": "GitHub issue #32: HARNESS-05 Add machine-checkable node report schema and PR evidence gate",
+  "changed_files": [
+    ".github/pull_request_template.md",
+    ".github/workflows/autopilot-gate.yml",
+    "ChromeWheelRouter/docs/development/node_reports/HARNESS-05.md",
+    "ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-05.md",
+    "harness/quality_gates.yml",
+    "project_control/autopilot_gate_policy.md",
+    "project_control/go_no_go_policy.md",
+    "scripts/check_harness_consistency.py",
+    "scripts/check_node_report.py",
+    "templates/node_report.md",
+    "templates/node_report.schema.json"
+  ],
+  "commands_run": [
+    {
+      "command": "python3 scripts/run_gate.py fast",
+      "result": "passed",
+      "summary": "Fast gate passed, including static safety, core routing smoke tests, router fixtures, Swift boundary checks, hot-path safety, node report validation, and harness consistency."
+    },
+    {
+      "command": "./scripts/check_all.sh",
+      "result": "blocked after fast gate by local XCTest availability",
+      "summary": "Fast gate passed, then local SwiftPM test build failed with `no such module 'XCTest'` in this Command Line Tools environment."
+    }
+  ],
+  "safety_invariants_checked": [
+    {
+      "invariant": "no_key_down_key_up_listeners",
+      "checked": true,
+      "summary": "Harness-only change; no event tap mask or keyboard event listener code changed."
+    },
+    {
+      "invariant": "no_network_or_telemetry",
+      "checked": true,
+      "summary": "No app networking or telemetry was added."
+    },
+    {
+      "invariant": "no_chrome_or_logi_config_access",
+      "checked": true,
+      "summary": "No Chrome profile, Chrome settings, or Logi Options+ files are read or modified."
+    },
+    {
+      "invariant": "no_root_privileged_helper_or_system_daemon",
+      "checked": true,
+      "summary": "No install, daemon, helper, root, kernel, or system extension behavior changed."
+    },
+    {
+      "invariant": "unmatched_events_pass_through",
+      "checked": true,
+      "summary": "No router or runtime event handling code changed."
+    }
+  ],
+  "scope_change": {
+    "changed": false,
+    "summary": "No product scope change; this adds PR evidence validation for harness quality gates."
+  },
+  "manual_validation_required": {
+    "required": false,
+    "summary": "No runtime, packaging, install, or product behavior changed."
+  },
+  "artifacts": [
+    "templates/node_report.schema.json",
+    "scripts/check_node_report.py",
+    "ChromeWheelRouter/docs/development/node_reports/HARNESS-05.md"
+  ],
+  "known_risks": [
+    "Legacy node reports remain readable but are not retroactively converted; CI validates changed structured reports."
+  ],
+  "next_node": "HARNESS-06",
+  "state_updates": {
+    "current_state_json_changed": false,
+    "summary": "No change to agent_state_harness/current_state.json."
+  }
+}
+```
+
+## Summary
+
+HARNESS-05 adds a structured evidence contract for new node reports. The PR gate
+now validates changed node reports with `scripts/check_node_report.py` instead of
+only checking that a report file exists.
+
+## Validation Notes
+
+Additional validation:
+
+- `env PYTHONPYCACHEPREFIX=/private/tmp/cwr_pycache python3 -m py_compile scripts/check_node_report.py scripts/check_harness_consistency.py`: passed.
+- `python3 -S scripts/check_node_report.py --all`: passed.
+- `python3 -S scripts/check_node_report.py --base origin/main --head HEAD`: intentionally failed before commit because there was no committed PR diff yet; rerun after commit.
+- `swift build -c release`: passed.

--- a/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-05.md
+++ b/ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-05.md
@@ -1,0 +1,18 @@
+# HARNESS-05 Summary
+
+Added machine-checkable node report evidence for PR gates.
+
+New node reports should include a fenced `json node-report` block whose fields
+match `templates/node_report.schema.json`. The validator
+`scripts/check_node_report.py` checks required fields, required command evidence,
+safety invariant coverage, changed-file coverage, scope/state explanations, and
+manual-validation heuristics.
+
+The Autopilot Gate now validates changed node reports on pull requests with:
+
+```bash
+python3 scripts/check_node_report.py --base "origin/${{ github.base_ref }}" --head HEAD
+```
+
+Legacy node reports are not retroactively converted by this node. New or changed
+reports must use the structured evidence block.

--- a/harness/quality_gates.yml
+++ b/harness/quality_gates.yml
@@ -11,6 +11,7 @@ gates:
       - "./scripts/check_router_fixtures.sh"
       - "./scripts/check_swift_boundaries.sh"
       - "./scripts/check_hot_path_safety.sh"
+      - "python3 -S ./scripts/check_node_report.py --all"
       - "python3 -S ./scripts/check_harness_consistency.py"
 
   integration:

--- a/project_control/autopilot_gate_policy.md
+++ b/project_control/autopilot_gate_policy.md
@@ -26,3 +26,17 @@ Low-touch mode:
 4. Owner only reviews failed gates and final RC.
 
 Do not use fully unattended release for v0.1.0. The app touches macOS input events; human local acceptance is mandatory.
+
+## Machine-checkable PR evidence
+
+Every Codex PR must add or update a node report under
+`ChromeWheelRouter/docs/development/node_reports/`. New reports must include a
+fenced `json node-report` evidence block matching
+`templates/node_report.schema.json`.
+
+The Autopilot Gate validates changed PR node reports with
+`scripts/check_node_report.py`. The gate fails when a PR has no node report, a
+report omits required evidence, required command results are missing, safety
+invariants are incomplete, changed files are not listed, manual-validation
+requirements are understated, or source-of-truth changes lack an explicit
+state/scope explanation.

--- a/project_control/go_no_go_policy.md
+++ b/project_control/go_no_go_policy.md
@@ -38,12 +38,13 @@
 每个 Codex PR 必须包含：
 
 - 对应 node report：`ChromeWheelRouter/docs/development/node_reports/EXEC-XX.md`
+- 结构化 node report evidence：fenced `json node-report` block matching `templates/node_report.schema.json`
 - 测试结果摘要
 - 改动范围摘要
 - 安全约束确认
 - 人类验证步骤
 
-没有 node report，不合并。
+没有 node report，或 node report 结构化 evidence gate 不通过，不合并。
 
 ## Scope Creep 拦截
 

--- a/scripts/check_harness_consistency.py
+++ b/scripts/check_harness_consistency.py
@@ -45,8 +45,10 @@ def main() -> int:
         require_contains("harness/quality_gates.yml", "./scripts/check_swift_boundaries.sh")
         require_contains("harness/quality_gates.yml", "./scripts/check_hot_path_safety.sh")
         require_contains("harness/quality_gates.yml", "./scripts/check_router_fixtures.sh")
+        require_contains("harness/quality_gates.yml", "python3 -S ./scripts/check_node_report.py --all")
         require_contains(".github/workflows/ci.yml", "python3 scripts/run_gate.py integration")
         require_contains(".github/workflows/autopilot-gate.yml", "python3 scripts/run_gate.py integration")
+        require_contains(".github/workflows/autopilot-gate.yml", "python3 scripts/check_node_report.py --base")
     except AssertionError as exc:
         print(f"harness consistency check failed: {exc}", file=sys.stderr)
         return 1

--- a/scripts/check_node_report.py
+++ b/scripts/check_node_report.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Validate structured node report evidence blocks.
+
+New node reports should include a fenced JSON block with an info string that
+contains "node-report". The block is validated against the repository schema and
+against PR-specific changed-file heuristics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_REPORT_DIR = ROOT / "ChromeWheelRouter" / "docs" / "development" / "node_reports"
+SCHEMA_PATH = ROOT / "templates" / "node_report.schema.json"
+NODE_REPORT_PREFIX = "ChromeWheelRouter/docs/development/node_reports/"
+
+REQUIRED_COMMANDS = (
+    "python3 scripts/run_gate.py fast",
+    "./scripts/check_all.sh",
+)
+
+REQUIRED_INVARIANTS = {
+    "no_key_down_key_up_listeners",
+    "no_network_or_telemetry",
+    "no_chrome_or_logi_config_access",
+    "no_root_privileged_helper_or_system_daemon",
+    "unmatched_events_pass_through",
+}
+
+MANUAL_VALIDATION_PATHS = (
+    "Sources/ChromeWheelRouterApp/",
+    "Sources/ChromeWheelRouterCLI/",
+    "Sources/ChromeWheelRouterMac/",
+    "scripts/install_dev.sh",
+    "scripts/uninstall_dev.sh",
+    "scripts/package_rc.sh",
+    "ChromeWheelRouter/docs/acceptance/",
+    "ChromeWheelRouter/docs/product/",
+)
+
+SCOPE_CHANGE_PATHS = (
+    "ChromeWheelRouter/docs/specs/scope.md",
+    "ChromeWheelRouter/docs/specs/product_scope.md",
+    "ChromeWheelRouter/docs/specs/product_decisions.md",
+    "agent_state_harness/current_state.json",
+)
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    print(f"node report check failed: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_git(args: list[str]) -> list[str]:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ValidationError(completed.stderr.strip() or f"git {' '.join(args)} failed")
+    return [line for line in completed.stdout.splitlines() if line]
+
+
+def changed_files(base: str | None, head: str) -> list[str]:
+    if base:
+        return run_git(["diff", "--name-only", f"{base}...{head}"])
+    return run_git(["diff", "--name-only", "HEAD"])
+
+
+def node_reports_from_changed_files(files: list[str]) -> list[Path]:
+    reports: list[Path] = []
+    for path in files:
+        if path.startswith(NODE_REPORT_PREFIX) and path.endswith(".md"):
+            reports.append(ROOT / path)
+    return sorted(set(reports))
+
+
+def structured_reports() -> list[Path]:
+    reports: list[Path] = []
+    for path in sorted(NODE_REPORT_DIR.glob("*.md")):
+        if "node-report" in path.read_text(encoding="utf-8"):
+            reports.append(path)
+    return reports
+
+
+def extract_evidence(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(r"```(?P<info>[^\n`]*)\n(?P<body>.*?)\n```", re.DOTALL)
+    for match in pattern.finditer(text):
+        info = match.group("info").strip().lower()
+        if "node-report" not in info:
+            continue
+        try:
+            evidence = json.loads(match.group("body"))
+        except json.JSONDecodeError as exc:
+            raise ValidationError(f"{path}: node-report JSON is malformed: {exc}") from exc
+        if not isinstance(evidence, dict):
+            raise ValidationError(f"{path}: node-report block must be a JSON object")
+        return evidence
+    raise ValidationError(f"{path}: missing fenced JSON node-report evidence block")
+
+
+def validate_type(path: Path, value: Any, schema: dict[str, Any], location: str = "node_report") -> None:
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        if not isinstance(value, dict):
+            raise ValidationError(f"{path}: {location} must be an object")
+        for key in schema.get("required", []):
+            if key not in value:
+                raise ValidationError(f"{path}: missing required field {location}.{key}")
+        properties = schema.get("properties", {})
+        for key, child in properties.items():
+            if key in value:
+                validate_type(path, value[key], child, f"{location}.{key}")
+    elif expected_type == "array":
+        if not isinstance(value, list):
+            raise ValidationError(f"{path}: {location} must be an array")
+        min_items = schema.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            raise ValidationError(f"{path}: {location} must contain at least {min_items} item(s)")
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(value):
+                validate_type(path, item, item_schema, f"{location}[{index}]")
+    elif expected_type == "string":
+        if not isinstance(value, str):
+            raise ValidationError(f"{path}: {location} must be a string")
+        if schema.get("minLength", 0) > 0 and not value.strip():
+            raise ValidationError(f"{path}: {location} must not be empty")
+    elif expected_type == "boolean":
+        if not isinstance(value, bool):
+            raise ValidationError(f"{path}: {location} must be a boolean")
+
+
+def validate_semantics(path: Path, evidence: dict[str, Any], changed: list[str] | None) -> None:
+    node_id = evidence["node_id"]
+    if path.stem != node_id:
+        raise ValidationError(f"{path}: node_id must match filename stem {path.stem!r}")
+
+    commands = {item["command"]: item for item in evidence["commands_run"]}
+    for command in REQUIRED_COMMANDS:
+        if command not in commands:
+            raise ValidationError(f"{path}: missing required command evidence: {command}")
+        if commands[command]["result"].strip().lower() in {"", "missing", "not run"}:
+            raise ValidationError(f"{path}: command {command!r} must include a concrete result")
+
+    invariants = {item["invariant"]: item for item in evidence["safety_invariants_checked"]}
+    missing_invariants = REQUIRED_INVARIANTS - set(invariants)
+    if missing_invariants:
+        raise ValidationError(f"{path}: missing safety invariants: {', '.join(sorted(missing_invariants))}")
+    unchecked = [name for name in REQUIRED_INVARIANTS if not invariants[name]["checked"]]
+    if unchecked:
+        raise ValidationError(f"{path}: safety invariants are not checked: {', '.join(sorted(unchecked))}")
+
+    if changed is not None:
+        changed_set = set(changed)
+        report_files = set(evidence["changed_files"])
+        missing_files = sorted(
+            item
+            for item in changed_set
+            if item != str(path.relative_to(ROOT)) and item not in report_files
+        )
+        if missing_files:
+            raise ValidationError(f"{path}: changed_files omits PR changes: {', '.join(missing_files)}")
+
+        manual_required = any(item.startswith(MANUAL_VALIDATION_PATHS) for item in changed_set)
+        if manual_required and not evidence["manual_validation_required"]["required"]:
+            raise ValidationError(f"{path}: changed files require manual validation, but report says none required")
+
+        current_state_changed = "agent_state_harness/current_state.json" in changed_set
+        if current_state_changed != evidence["state_updates"]["current_state_json_changed"]:
+            raise ValidationError(f"{path}: current_state.json change status is not accurately reported")
+
+        scope_paths_changed = any(item in changed_set for item in SCOPE_CHANGE_PATHS)
+        if scope_paths_changed and not evidence["scope_change"]["changed"]:
+            raise ValidationError(f"{path}: scope/source-of-truth changed without scope_change statement")
+
+    if not evidence["artifacts"]:
+        raise ValidationError(f"{path}: artifacts must include at least the node report path or changed evidence")
+
+
+def validate_reports(reports: list[Path], changed: list[str] | None) -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    for report in reports:
+        if not report.exists():
+            raise ValidationError(f"missing node report: {report}")
+        evidence = extract_evidence(report)
+        validate_type(report, evidence, schema)
+        validate_semantics(report, evidence, changed)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate structured node report evidence.")
+    parser.add_argument("--base", help="Base ref for PR changed-file validation.")
+    parser.add_argument("--head", default="HEAD", help="Head ref for PR changed-file validation.")
+    parser.add_argument("--all", action="store_true", help="Validate all structured node reports.")
+    args = parser.parse_args()
+
+    try:
+        if args.base:
+            changed = changed_files(args.base, args.head)
+            reports = node_reports_from_changed_files(changed)
+            if not reports:
+                raise ValidationError(
+                    f"PR changes must include a node report under {NODE_REPORT_PREFIX}"
+                )
+            validate_reports(reports, changed)
+        else:
+            reports = structured_reports()
+            if not reports:
+                raise ValidationError("no structured node reports found")
+            validate_reports(reports, None if args.all else changed_files(None, args.head))
+    except ValidationError as exc:
+        fail(str(exc))
+
+    print(f"node report checks: OK ({len(reports)} report(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_node_report.py
+++ b/scripts/check_node_report.py
@@ -50,7 +50,6 @@ SCOPE_CHANGE_PATHS = (
     "ChromeWheelRouter/docs/specs/scope.md",
     "ChromeWheelRouter/docs/specs/product_scope.md",
     "ChromeWheelRouter/docs/specs/product_decisions.md",
-    "agent_state_harness/current_state.json",
 )
 
 

--- a/templates/node_report.md
+++ b/templates/node_report.md
@@ -1,5 +1,73 @@
 # Node Report: <NODE-ID>
 
+## Machine-readable evidence
+
+```json node-report
+{
+  "node_id": "<NODE-ID>",
+  "task_source": "<GitHub issue, execution prompt, or owner request>",
+  "changed_files": [
+    "<path>"
+  ],
+  "commands_run": [
+    {
+      "command": "python3 scripts/run_gate.py fast",
+      "result": "<passed | failed | blocked with reason>",
+      "summary": "<short result summary>"
+    },
+    {
+      "command": "./scripts/check_all.sh",
+      "result": "<passed | failed | blocked with reason>",
+      "summary": "<short result summary>"
+    }
+  ],
+  "safety_invariants_checked": [
+    {
+      "invariant": "no_key_down_key_up_listeners",
+      "checked": true,
+      "summary": "<evidence>"
+    },
+    {
+      "invariant": "no_network_or_telemetry",
+      "checked": true,
+      "summary": "<evidence>"
+    },
+    {
+      "invariant": "no_chrome_or_logi_config_access",
+      "checked": true,
+      "summary": "<evidence>"
+    },
+    {
+      "invariant": "no_root_privileged_helper_or_system_daemon",
+      "checked": true,
+      "summary": "<evidence>"
+    },
+    {
+      "invariant": "unmatched_events_pass_through",
+      "checked": true,
+      "summary": "<evidence>"
+    }
+  ],
+  "scope_change": {
+    "changed": false,
+    "summary": "<scope statement>"
+  },
+  "manual_validation_required": {
+    "required": false,
+    "summary": "<manual validation statement>"
+  },
+  "artifacts": [
+    "<path>"
+  ],
+  "known_risks": [],
+  "next_node": "<NEXT-NODE>",
+  "state_updates": {
+    "current_state_json_changed": false,
+    "summary": "<state update statement>"
+  }
+}
+```
+
 ## Node
 
 - ID:

--- a/templates/node_report.schema.json
+++ b/templates/node_report.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ChromeWheelRouter Node Report Evidence",
+  "type": "object",
+  "required": [
+    "node_id",
+    "task_source",
+    "changed_files",
+    "commands_run",
+    "safety_invariants_checked",
+    "scope_change",
+    "manual_validation_required",
+    "artifacts",
+    "known_risks",
+    "next_node",
+    "state_updates"
+  ],
+  "properties": {
+    "node_id": {"type": "string", "minLength": 1},
+    "task_source": {"type": "string", "minLength": 1},
+    "changed_files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "commands_run": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["command", "result", "summary"],
+        "properties": {
+          "command": {"type": "string", "minLength": 1},
+          "result": {"type": "string", "minLength": 1},
+          "summary": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "safety_invariants_checked": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["invariant", "checked", "summary"],
+        "properties": {
+          "invariant": {"type": "string", "minLength": 1},
+          "checked": {"type": "boolean"},
+          "summary": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "scope_change": {
+      "type": "object",
+      "required": ["changed", "summary"],
+      "properties": {
+        "changed": {"type": "boolean"},
+        "summary": {"type": "string", "minLength": 1}
+      }
+    },
+    "manual_validation_required": {
+      "type": "object",
+      "required": ["required", "summary"],
+      "properties": {
+        "required": {"type": "boolean"},
+        "summary": {"type": "string", "minLength": 1}
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "known_risks": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "next_node": {"type": "string", "minLength": 1},
+    "state_updates": {
+      "type": "object",
+      "required": ["current_state_json_changed", "summary"],
+      "properties": {
+        "current_state_json_changed": {"type": "boolean"},
+        "summary": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `templates/node_report.schema.json` and `scripts/check_node_report.py` for structured node report validation.
- Update the PR template and node report template with a fenced `json node-report` evidence block.
- Wire the Autopilot Gate to validate changed PR node reports, and add local fast-gate coverage for structured report checks.
- Add HARNESS-05 node report and project-memory summary.

## Why

Issue #32 asks for PR evidence to be machine-checkable instead of relying only on free-form node reports. This PR makes changed node reports validate required fields, command evidence, safety invariant coverage, changed-file coverage, manual-validation heuristics, and source-of-truth/scope explanations.

## Related Context

- Closes #32
- Specs/harness checked: `ChromeWheelRouter/docs/specs/scope.md`, `ChromeWheelRouter/docs/specs/safety_constraints.md`, `ChromeWheelRouter/docs/specs/hot_path_rules.md`, `ChromeWheelRouter/docs/specs/architecture.md`, `agent_state_harness/current_state.json`, `project_control/engineering_nodes.md`
- Project control updated: `project_control/autopilot_gate_policy.md`, `project_control/go_no_go_policy.md`
- Project memory added: `ChromeWheelRouter/docs/development/project_memory/node_summaries/HARNESS-05.md`

## PR Reuse Check

- Existing PR for branch: none found via `gh pr list --head codex/issue-32-node-report-gate --state all`
- Action taken: created a new draft PR

## Confidence Proof

- The validator uses only Python stdlib and validates fenced `json node-report` blocks against the repository schema plus semantic checks.
- PR mode requires at least one changed node report and validates the changed-file list against the PR diff.
- Safety evidence requires all core safety invariants to be present and checked.
- Manual-validation and source-of-truth heuristics fail when changed files make those statements inaccurate.
- Legacy node reports remain readable; this PR does not attempt a broad historical conversion outside issue scope.

## Conflict / Target-Branch Check

- Target branch: `origin/main`
- Merge base: `5ac7c070f4ff2356fd7af7457a2414b546f37323`
- Conflict status: no target-branch drift; branch was created from current `origin/main`

## Validation

- `env PYTHONPYCACHEPREFIX=/private/tmp/cwr_pycache python3 -m py_compile scripts/check_node_report.py scripts/check_harness_consistency.py`: passed
- `python3 -S scripts/check_node_report.py --all`: passed
- `python3 -S scripts/check_node_report.py --base origin/main --head HEAD`: passed after commit
- `python3 scripts/run_gate.py fast`: passed
- `git diff --check`: passed
- `swift build -c release`: passed
- `./scripts/check_all.sh`: fast gate passed, then local `swift test` failed because this Command Line Tools environment cannot import XCTest: `no such module 'XCTest'`

## CI Readiness

- CI status: pending after PR creation
- Draft status after CI: draft until GitHub CI proves the full gate, since local XCTest is unavailable