### PR TITLE
Guard CLI entrypoint for non-macOS builds

### DIFF
--- a/Sources/ChromeWheelRouterCLI/main.swift
+++ b/Sources/ChromeWheelRouterCLI/main.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit)
 import AppKit
 import Foundation
 import ChromeWheelRouterMac
@@ -85,3 +86,9 @@ struct CLI {
 }
 
 try CLI.run(arguments: CommandLine.arguments.dropFirst().map { $0 })
+
+#else
+import Foundation
+fputs("ChromeWheelRouterCLI requires macOS (AppKit).\n", stderr)
+Foundation.exit(1)
+#endif


### PR DESCRIPTION
### Motivation
- CI and local checks failed when non-macOS toolchains attempted to compile the CLI target because `AppKit` is macOS-only.  
- The project needs to allow cross-platform `./scripts/check_all.sh` and CI workflows to run without changing macOS runtime behavior.  

### Description
- Wrap `Sources/ChromeWheelRouterCLI/main.swift` in `#if canImport(AppKit)` so the AppKit-dependent CLI code is compiled only on macOS.  
- Add a non-macOS fallback that imports `Foundation`, prints a clear error message, and exits so non-macOS builds fail fast with a helpful message.  
- Preserve existing macOS behavior and entry points unchanged inside the `canImport(AppKit)` branch.  

### Testing
- Ran `./scripts/check_all.sh` and it completed successfully (previous build error from `AppKit` import was resolved).  
- Ran `swift test` and all unit tests passed.  
- Ran `swift build -c release` and the release build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36284e86083239a71802fe4a6cb82)